### PR TITLE
Avoid root-level wrapping for Map-like types, not just Maps

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/util/TypeUtil.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/util/TypeUtil.java
@@ -21,7 +21,7 @@ public class TypeUtil
                 return false;
             }
             // issue#5: also, should not add wrapping for Maps
-            if (Map.class.isAssignableFrom(cls)) {
+            if (type.isMapLikeType()) {
                 return false;
             }
             return true;


### PR DESCRIPTION
Custom map-like types is still wrapped (see [this](https://github.com/ruslansennov/javaslang-jackson/blob/fa5d70f37006eb94f705fe6f12aaccb63cfe39f4/src/test/java/javaslang/jackson/datatype/map/MapTest.java#L126) failed test)