### PR TITLE
Adding writeRawValue method support to ToXmlGenerator.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -655,6 +655,82 @@ public final class ToXmlGenerator
      */
 
     @Override
+    public void writeRawValue(String text) throws IOException {
+        // [dataformat-xml#39]
+        if (_stax2Emulation) {
+            _reportUnimplementedStax2("writeRawValue");
+        }
+        try {
+            _verifyValueWrite("write raw value");
+            if (_nextName == null) {
+                handleMissingName();
+            }
+
+            if (_nextIsAttribute) {
+                _xmlWriter.writeAttribute(_nextName.getNamespaceURI(), _nextName.getLocalPart(), text);
+            } else {
+                _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
+                _xmlWriter.writeRaw(text);
+                _xmlWriter.writeEndElement();
+            }
+        } catch (XMLStreamException e) {
+            StaxUtil.throwXmlAsIOException(e);
+        }
+    }
+
+    @Override
+    public void writeRawValue(String text, int offset, int len) throws IOException {
+        // [dataformat-xml#39]
+        if (_stax2Emulation) {
+            _reportUnimplementedStax2("writeRawValue");
+        }
+        try {
+            _verifyValueWrite("write raw value");
+            if (_nextName == null) {
+                handleMissingName();
+            }
+
+            if (_nextIsAttribute) {
+                _xmlWriter.writeAttribute(_nextName.getNamespaceURI(), _nextName.getLocalPart(), text.substring(offset, offset + len));
+            } else {
+                _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
+                _xmlWriter.writeRaw(text, offset, len);
+                _xmlWriter.writeEndElement();
+            }
+        } catch (XMLStreamException e) {
+            StaxUtil.throwXmlAsIOException(e);
+        }
+    }
+
+    @Override
+    public void writeRawValue(char[] text, int offset, int len) throws IOException {
+        // [dataformat-xml#39]
+        if (_stax2Emulation) {
+            _reportUnimplementedStax2("writeRawValue");
+        }
+        _verifyValueWrite("write raw value");
+        if (_nextName == null) {
+            handleMissingName();
+        }
+        try {
+            if (_nextIsAttribute) {
+                _xmlWriter.writeAttribute(_nextName.getNamespaceURI(), _nextName.getLocalPart(), new String(text, offset, len));
+            } else {
+                _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
+                _xmlWriter.writeRaw(text, offset, len);
+                _xmlWriter.writeEndElement();
+            }
+        } catch (XMLStreamException e) {
+            StaxUtil.throwXmlAsIOException(e);
+        }
+    }
+
+    @Override
+    public void writeRawValue(SerializableString text) throws IOException {
+        _reportUnsupportedOperation();
+    }
+
+    @Override
     public void writeRaw(String text) throws IOException
     {
         // [dataformat-xml#39]

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlGeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlGeneratorTest.java
@@ -105,5 +105,119 @@ public class XmlGeneratorTest extends XmlTestBase
 
         assertEquals("<IntWrapper><i>42</i></IntWrapper>", xml);
         f.delete();
-    }    
+    }
+
+    public void testRawSimpleValue() throws Exception
+    {
+        XmlFactory f = new XmlFactory();
+        StringWriter out = new StringWriter();
+        ToXmlGenerator gen = f.createGenerator(out);
+        // root name is special, need to be fed first:
+        gen.setNextName(new QName("root"));
+        gen.writeStartObject();
+        gen.writeFieldName("elem");
+        gen.writeRawValue("value");
+        gen.writeEndObject();
+        gen.close();
+        String xml = out.toString();
+        // one more thing: remove that annoying 'xmlns' decl, if it's there:
+        xml = removeSjsxpNamespace(xml);
+        assertEquals("<root><elem>value</elem></root>", xml);
+    }
+
+    public void testRawOffsetValue() throws Exception
+    {
+        XmlFactory f = new XmlFactory();
+        StringWriter out = new StringWriter();
+        ToXmlGenerator gen = f.createGenerator(out);
+        // root name is special, need to be fed first:
+        gen.setNextName(new QName("root"));
+        gen.writeStartObject();
+        gen.writeFieldName("elem");
+        gen.writeRawValue("NotAValue_value_NotAValue", 10, 5);
+        gen.writeEndObject();
+        gen.close();
+        String xml = out.toString();
+        // one more thing: remove that annoying 'xmlns' decl, if it's there:
+        xml = removeSjsxpNamespace(xml);
+        assertEquals("<root><elem>value</elem></root>", xml);
+    }
+
+    public void testRawCharArrayValue() throws Exception
+    {
+        XmlFactory f = new XmlFactory();
+        StringWriter out = new StringWriter();
+        ToXmlGenerator gen = f.createGenerator(out);
+        // root name is special, need to be fed first:
+        gen.setNextName(new QName("root"));
+        gen.writeStartObject();
+        gen.writeFieldName("elem");
+        gen.writeRawValue(new char[] {'!', 'v', 'a', 'l', 'u', 'e', '!'}, 1, 5);
+        gen.writeEndObject();
+        gen.close();
+        String xml = out.toString();
+        // one more thing: remove that annoying 'xmlns' decl, if it's there:
+        xml = removeSjsxpNamespace(xml);
+        assertEquals("<root><elem>value</elem></root>", xml);
+    }
+
+    public void testRawSimpleAttribute() throws Exception
+    {
+        XmlFactory f = new XmlFactory();
+        StringWriter out = new StringWriter();
+        ToXmlGenerator gen = f.createGenerator(out);
+        // root name is special, need to be fed first:
+        gen.setNextName(new QName("root"));
+        gen.writeStartObject();
+        // and also need to force attribute
+        gen.setNextIsAttribute(true);
+        gen.writeFieldName("attr");
+        gen.writeRawValue("value");
+        gen.writeEndObject();
+        gen.close();
+        String xml = out.toString();
+        // one more thing: remove that annoying 'xmlns' decl, if it's there:
+        xml = removeSjsxpNamespace(xml);
+        assertEquals("<root attr=\"value\"/>", xml);
+    }
+
+    public void testRawOffsetAttribute() throws Exception
+    {
+        XmlFactory f = new XmlFactory();
+        StringWriter out = new StringWriter();
+        ToXmlGenerator gen = f.createGenerator(out);
+        // root name is special, need to be fed first:
+        gen.setNextName(new QName("root"));
+        gen.writeStartObject();
+        // and also need to force attribute
+        gen.setNextIsAttribute(true);
+        gen.writeFieldName("attr");
+        gen.writeRawValue("NotAValue_value_NotAValue", 10, 5);
+        gen.writeEndObject();
+        gen.close();
+        String xml = out.toString();
+        // one more thing: remove that annoying 'xmlns' decl, if it's there:
+        xml = removeSjsxpNamespace(xml);
+        assertEquals("<root attr=\"value\"/>", xml);
+    }
+
+    public void testRawCharArratAttribute() throws Exception
+    {
+        XmlFactory f = new XmlFactory();
+        StringWriter out = new StringWriter();
+        ToXmlGenerator gen = f.createGenerator(out);
+        // root name is special, need to be fed first:
+        gen.setNextName(new QName("root"));
+        gen.writeStartObject();
+        // and also need to force attribute
+        gen.setNextIsAttribute(true);
+        gen.writeFieldName("attr");
+        gen.writeRawValue(new char[]{'!', 'v', 'a', 'l', 'u', 'e', '!'}, 1, 5);
+        gen.writeEndObject();
+        gen.close();
+        String xml = out.toString();
+        // one more thing: remove that annoying 'xmlns' decl, if it's there:
+        xml = removeSjsxpNamespace(xml);
+        assertEquals("<root attr=\"value\"/>", xml);
+    }
 }


### PR DESCRIPTION
Currently only writeRaw methods are supported.
Default implementation for writeRawValue from GeneratorBase redirects call to writeRaw.
This lead to element name to be ignored which in order leads to invalid XML.

This change will allow to write 'writeRawValue' code in the same fashion as Json one and generating valid XML
