### PR TITLE
Amending Android usage notes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,9 @@ XmlMapper xmlMapper = new XmlMapper(module);
 as many features that `XmlMapper` needs are provided by `JacksonXmlModule`; default
 `XmlMapper` simply constructs module with default settings.
 
-## Android quirks
+## Android
 
-While usage on Android is the same as on standard JDKs, there is one thing that may cause issues:
-since Google has chosen not to include whole JDK 1.6 API, `Stax` API (package `javax.xml.stream`) is missing.
-This means that one has to add dependency explicitly. With Maven it can be done with
-
-```xml
-<dependency>
-    <groupId>javax.xml.stream</groupId>
-    <artifactId>stax-api</artifactId>
-    <version>1.0-2</version>
-    <scope>compile</scope>
-</dependency>
-```
-
-or, if using other build tools, include similar dependency or download actual jar from
-
-    http://repo1.maven.org/maven2/javax/xml/stream/stax-api/1.0-2/
+Usage of this library on Android is currently not supported. This is due to the fact that the Stax API is unavailable on the Android platform, and attempts to declare an explicit dependency on the Stax API library will result in errors at build time (since the inclusion of the `javax.*` namespace in apps is restricted).
 
 ## Serializing POJOs as XML
 


### PR DESCRIPTION
As of recent versions of Android the current Android-specific instructions in the README are broken. 

If you declare an explicit dependency on the Stax API the Android build tools will fail your build when you attempt to package a non-debuggable version of your app (necessary for publishing to the Play Store). This issue was reported [here](https://github.com/FasterXML/jackson-dataformat-xml/issues/142) and [here](https://github.com/FasterXML/jackson-dataformat-xml/issues/238).

There are (extremely hacky) [workarounds](https://stackoverflow.com/questions/31360025/using-jackson-dataformat-xml-on-android) that exist, but others have reported unresolved problems with them.

I would advocate explicitly declaring that Android usage is currently unsupported since:
 * In the comments to the aforementioned (closed) issues the official response reads something like: `I don't know: I don't develop on Android. Please ask on mailing lists.`
 * Based on the assumption that it was supported, I personally invested a fair amount of time adopting your library in my Android project, only to find when I came to publish my app to the Play Store that it wasn't. It seems like it would be fairer to be brutally honest upfront with your users

Thanks otherwise for a nice library.





