### PR TITLE
Replaced slow string concatenation with faster StringBuilder

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -377,39 +377,43 @@ public class XmlTokenStream
             return "";
         }
 
-        StringBuilder textBuilder = null;
+        CharSequence chars = null;
         while (true) {
             switch (_xmlReader.next()) {
-            case XMLStreamConstants.START_ELEMENT:
-                return textBuilder == null ? "" : textBuilder.toString();
+                case XMLStreamConstants.START_ELEMENT:
+                    return chars == null ? "" : chars.toString();
 
-            case XMLStreamConstants.END_ELEMENT:
-            case XMLStreamConstants.END_DOCUMENT:
-                // 04-May-2018, tatu: For 3.0 we can actually start exposing <tag></tag> ALSO
-                //    as `null`, as long as we default `String` null handling to coerce that to
-                //    "empty"
-                if (textBuilder == null) {
-                    if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
-                        return null;
+                case XMLStreamConstants.END_ELEMENT:
+                case XMLStreamConstants.END_DOCUMENT:
+                    // 04-May-2018, tatu: For 3.0 we can actually start exposing <tag></tag> ALSO
+                    //    as `null`, as long as we default `String` null handling to coerce that to
+                    //    "empty"
+                    if (chars == null) {
+                        if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
+                            return null;
+                        }
+                        return "";
                     }
-                    return "";
-                }
-                return textBuilder.toString();
+                    return chars.toString();
 
-            // note: SPACE is ignorable (and seldom seen), not to be included
-            case XMLStreamConstants.CHARACTERS:
-            case XMLStreamConstants.CDATA:
-                // 17-Jul-2017, tatu: as per [dataformat-xml#236], need to try to...
+                // note: SPACE is ignorable (and seldom seen), not to be included
+                case XMLStreamConstants.CHARACTERS:
+                case XMLStreamConstants.CDATA:
+                    // 17-Jul-2017, tatu: as per [dataformat-xml#236], need to try to...
                 {
                     String str = _getText(_xmlReader);
-                    if (textBuilder == null) {
-                        textBuilder = new StringBuilder();
+                    if (chars == null) {
+                        chars = str;
+                    } else  {
+                        if (chars instanceof String) {
+                            chars = new StringBuilder(chars);
+                        }
+                        ((StringBuilder)chars).append(str);
                     }
-                    textBuilder.append(str);
                 }
                 break;
-            default:
-                // any other type (proc instr, comment etc) is just ignored
+                default:
+                    // any other type (proc instr, comment etc) is just ignored
             }
         }
     }

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -377,24 +377,24 @@ public class XmlTokenStream
             return "";
         }
 
-        String text = null;
+        StringBuilder textBuilder = null;
         while (true) {
             switch (_xmlReader.next()) {
             case XMLStreamConstants.START_ELEMENT:
-                return (text == null) ? "" : text;
+                return textBuilder == null ? "" : textBuilder.toString();
 
             case XMLStreamConstants.END_ELEMENT:
             case XMLStreamConstants.END_DOCUMENT:
                 // 04-May-2018, tatu: For 3.0 we can actually start exposing <tag></tag> ALSO
                 //    as `null`, as long as we default `String` null handling to coerce that to
                 //    "empty"
-                if (text == null) {
+                if (textBuilder == null) {
                     if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
                         return null;
                     }
                     return "";
                 }
-                return text;
+                return textBuilder.toString();
 
             // note: SPACE is ignorable (and seldom seen), not to be included
             case XMLStreamConstants.CHARACTERS:
@@ -402,11 +402,10 @@ public class XmlTokenStream
                 // 17-Jul-2017, tatu: as per [dataformat-xml#236], need to try to...
                 {
                     String str = _getText(_xmlReader);
-                    if (text == null) {
-                        text = str;
-                    } else {
-                        text += str;
+                    if (textBuilder == null) {
+                        textBuilder = new StringBuilder();
                     }
+                    textBuilder.append(str);
                 }
                 break;
             default:


### PR DESCRIPTION
I found that small change to make a huge performance difference in some scenarios. In one case of processing a sample XML file of about 4 MB into POJOs, the CPU time sank by a factor of 100, from around 5–10 seconds to a few tens of milliseconds on a recent MacBook Pro with Azul OpenJDK 8.