### PR TITLE
Fix #336

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -1123,9 +1123,15 @@ public final class ToXmlGenerator
                 }
             } else {
                 if (_xmlPrettyPrinter != null) {
-                	_xmlPrettyPrinter.writeLeafElement(_xmlWriter,
-                			_nextName.getNamespaceURI(), _nextName.getLocalPart(),
-                			dec);
+                    if (usePlain) {
+                        _xmlPrettyPrinter.writeLeafElement(_xmlWriter,
+                                _nextName.getNamespaceURI(), _nextName.getLocalPart(),
+                                dec.toPlainString(), false);
+                    } else {
+                        _xmlPrettyPrinter.writeLeafElement(_xmlWriter,
+                                _nextName.getNamespaceURI(), _nextName.getLocalPart(),
+                                dec);
+                    }
                 } else {
 	                _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
 	                if (usePlain) {


### PR DESCRIPTION
Fixed usage of WRITE_BIGDECIMAL_AS_PLAIN when XML pretty printer is
configured.