### PR TITLE
Part of #360, use xsi:nil for null value with non-pretty writer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -1017,7 +1018,7 @@ public class ToXmlGenerator
                 } else {
                     if(isEnabled(Feature.WRITE_NULLS_AS_XSI_NIL)) {
                         _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
-                        _xmlWriter.writeAttribute(_nextName.getNamespaceURI(), "xsi:nil", "true");
+                        _xmlWriter.writeAttribute("xsi", XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "nil", "true");
                         _xmlWriter.writeEndElement();
                     } else {
                         _xmlWriter.writeEmptyElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -1015,7 +1015,13 @@ public class ToXmlGenerator
                 	_xmlPrettyPrinter.writeLeafNullElement(_xmlWriter,
                 			_nextName.getNamespaceURI(), _nextName.getLocalPart());
                 } else {
-	            	_xmlWriter.writeEmptyElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
+                    if(isEnabled(Feature.WRITE_NULLS_AS_XSI_NIL)) {
+                        _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
+                        _xmlWriter.writeAttribute(_nextName.getNamespaceURI(), "xsi:nil", "true");
+                        _xmlWriter.writeEndElement();
+                    } else {
+                        _xmlWriter.writeEmptyElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
+                    }
                 }
             }
         } catch (XMLStreamException e) {

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerialization.java
@@ -111,6 +111,16 @@ public class TestSerialization extends XmlTestBase
         assertEquals("<AttrAndElem id=\"42\"><elem>whatever</elem></AttrAndElem>", xml);
     }
 
+    public void testNil() throws IOException
+    {
+        XmlMapper mapper = new XmlMapper();
+        mapper.configure(ToXmlGenerator.Feature.WRITE_NULLS_AS_XSI_NIL, true);
+        WrapperBean<String> bean = new WrapperBean<>(null);
+        // First, map in a general wrapper
+        String xml = mapper.writeValueAsString(bean);
+        assertEquals("<WrapperBean><value xsi:nil=\"true\"/></WrapperBean>", xml);
+    }
+
     @SuppressWarnings("boxing")
     public void testMap() throws IOException
     {

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerialization.java
@@ -118,7 +118,7 @@ public class TestSerialization extends XmlTestBase
         WrapperBean<String> bean = new WrapperBean<>(null);
         // First, map in a general wrapper
         String xml = mapper.writeValueAsString(bean);
-        assertEquals("<WrapperBean><value xsi:nil=\"true\"/></WrapperBean>", xml);
+        assertEquals("<WrapperBean><value xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/></WrapperBean>", xml);
     }
 
     @SuppressWarnings("boxing")


### PR DESCRIPTION
I'm not necessarily a big fan of having this `xsi:nil` in the middle of the code, let me know if you think I should extract it to a constant / use an existing constant (I looked for one but didn't find any).