### PR TITLE
Fix: Problem when using defaultUseWrapper(false) in combination with polymorphic types

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/WrapperHandlingDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/WrapperHandlingDeserializer.java
@@ -160,7 +160,7 @@ public class WrapperHandlingDeserializer
             //   If so, need to refrain from adding wrapping as that would
             //   override parent settings
             JsonToken t = p.currentToken();
-            if (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY) {
+            if (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY || t == JsonToken.FIELD_NAME) {
                 ((FromXmlParser) p).addVirtualWrapping(_namesToWrap, _caseInsensitive);
             }
         }


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/FasterXML/jackson-dataformat-xml/commit/d9738d92bfe1ea4ff59c339cc42348fb70936ae4 , which lead to [this bug report](https://github.com/FasterXML/jackson-dataformat-xml/issues/490).