### PR TITLE
Fix 8 Flaky Tests

### DIFF
--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/jaxb/AttributesWithJAXBTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/jaxb/AttributesWithJAXBTest.java
@@ -6,7 +6,6 @@ import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.MapperFeature;
 
 public class AttributesWithJAXBTest extends XmlTestBase

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/jaxb/AttributesWithJAXBTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/jaxb/AttributesWithJAXBTest.java
@@ -6,6 +6,8 @@ import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.MapperFeature;
 
 public class AttributesWithJAXBTest extends XmlTestBase
 {
@@ -41,6 +43,7 @@ public class AttributesWithJAXBTest extends XmlTestBase
     {
         XmlMapper mapper = XmlMapper.builder()
                 .annotationIntrospector(jakartaXMLBindAnnotationIntrospector())
+		.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
                 .build();
         String xml = mapper.writeValueAsString(new Jurisdiction());
         assertEquals("<Jurisdiction name=\"Foo\" value=\"13\"/>", xml);

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/jaxb/WithJAXBAnnotationsTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/jaxb/WithJAXBAnnotationsTest.java
@@ -6,6 +6,7 @@ import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.dataformat.xml.XmlAnnotationIntrospector;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
@@ -47,6 +48,7 @@ public class WithJAXBAnnotationsTest extends XmlTestBase
     }
 
     @XmlRootElement(name = "Individual")
+    @JsonPropertyOrder({ "id", "firstName", "lastName"})
     static class MyPerson {
         @XmlAttribute(name = "identifier")
         public Long id;

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/Issue101UnwrappedListAttributesTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/Issue101UnwrappedListAttributesTest.java
@@ -21,7 +21,7 @@ public class Issue101UnwrappedListAttributesTest extends XmlTestBase
 
         public String name;
     }
-
+     @JsonPropertyOrder({ "id", "type" })
      static class UnwrappedElement {
         public UnwrappedElement () {}
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/ListAnnotationSharingTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/ListAnnotationSharingTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.xml.lists;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
@@ -21,6 +22,7 @@ public class ListAnnotationSharingTest extends XmlTestBase
         }
     }
 
+    @JsonPropertyOrder({"x", "y"})
     static class Point {
         public int x, y;
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/UnwrappingWithXMLTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/UnwrappingWithXMLTest.java
@@ -35,6 +35,7 @@ public class UnwrappingWithXMLTest extends XmlTestBase
         }
     }
 
+    @JsonPropertyOrder({ "name", "location" })
     static class UnwrappingWithAttributes{
         @JacksonXmlProperty(isAttribute=true)
         public String name;

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestIndentation.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestIndentation.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.xml.ser;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
@@ -57,6 +58,7 @@ public class TestIndentation extends XmlTestBase
         public List<Employee> employee = new ArrayList<Employee>();
     }
 
+    @JsonPropertyOrder({"id", "type"})
     static class Employee {
         public String id;
         public EmployeeType type;

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestJDKSerializability.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestJDKSerializability.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.xml.ser;
 import java.io.*;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
@@ -14,6 +15,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
 public class TestJDKSerializability extends XmlTestBase
 {
     @JsonRootName("MyPojo")
+    @JsonPropertyOrder({ "x", "y" })
     static class MyPojo {
         public int x;
         int y;

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationAttr.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationAttr.java
@@ -29,6 +29,7 @@ public class TestSerializationAttr extends XmlTestBase
         public String id = "abc";
     }
 
+    @JsonPropertyOrder({ "name", "value" })
     public class Jurisdiction {
         @JacksonXmlProperty(isAttribute=true)
         protected String name = "Foo";


### PR DESCRIPTION
Fixed eight flaky tests by using the annotation @JsonPropertyOrder and configuring map to guarantee the order. A ﬂaky test is an analysis of web application code that fails to produce the same result each time the same analysis is run. Flaky tests are detected by nondex (https://github.com/TestingResearchIllinois/NonDex) which is tool developped by the research group led by professor Darko at UIUC.

1. com.fasterxml.jackson.dataformat.xml.jaxb.AttributesWithJAXBTest#testTwoAttributes
2. com.fasterxml.jackson.dataformat.xml.jaxb.WithJAXBAnnotationsTest#testPersonAsXml
3. com.fasterxml.jackson.dataformat.xml.lists.ListAnnotationSharingTest#testAnnotationSharing
4. com.fasterxml.jackson.dataformat.xml.misc.UnwrappingWithXMLTest#testUnwrappingWithAttribute
5. com.fasterxml.jackson.dataformat.xml.ser.TestIndentation#testMultiLevel172
6. com.fasterxml.jackson.dataformat.xml.ser.TestJDKSerializability#testMapper
7. com.fasterxml.jackson.dataformat.xml.lists.Issue101UnwrappedListAttributesTest#testWithTwoAttributes
8. com.fasterxml.jackson.dataformat.xml.ser.TestSerializationAttr#testIssue6