### PR TITLE
Fix generating invalid XML tag names

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
@@ -65,6 +65,8 @@ public class XmlFactory extends JsonFactory
     protected transient XMLOutputFactory _xmlOutputFactory;
 
     protected String _cfgNameForTextElement;
+
+    protected XmlTagProcessor _tagProcessor;
     
     /*
     /**********************************************************
@@ -102,11 +104,18 @@ public class XmlFactory extends JsonFactory
                 xmlIn, xmlOut, null);
     }
 
+    public XmlFactory(ObjectCodec oc, int xpFeatures, int xgFeatures,
+                         XMLInputFactory xmlIn, XMLOutputFactory xmlOut,
+                         String nameForTextElem) {
+        this(oc, xpFeatures, xgFeatures, xmlIn, xmlOut, nameForTextElem, XmlTagProcessors.newPassthroughProcessor());
+    }
+
     protected XmlFactory(ObjectCodec oc, int xpFeatures, int xgFeatures,
             XMLInputFactory xmlIn, XMLOutputFactory xmlOut,
-            String nameForTextElem)
+            String nameForTextElem, XmlTagProcessor tagProcessor)
     {
         super(oc);
+        _tagProcessor = tagProcessor;
         _xmlParserFeatures = xpFeatures;
         _xmlGeneratorFeatures = xgFeatures;
         _cfgNameForTextElement = nameForTextElem;
@@ -140,6 +149,7 @@ public class XmlFactory extends JsonFactory
         _cfgNameForTextElement = src._cfgNameForTextElement;
         _xmlInputFactory = src._xmlInputFactory;
         _xmlOutputFactory = src._xmlOutputFactory;
+        _tagProcessor = src._tagProcessor;
     }
 
     /**
@@ -155,6 +165,7 @@ public class XmlFactory extends JsonFactory
         _cfgNameForTextElement = b.nameForTextElement();
         _xmlInputFactory = b.xmlInputFactory();
         _xmlOutputFactory = b.xmlOutputFactory();
+        _tagProcessor = b.xmlTagProcessor();
         _initFactories(_xmlInputFactory, _xmlOutputFactory);
     }
 
@@ -323,6 +334,14 @@ public class XmlFactory extends JsonFactory
     @Override
     public int getFormatGeneratorFeatures() {
         return _xmlGeneratorFeatures;
+    }
+
+    public XmlTagProcessor getXmlTagProcessor() {
+        return _tagProcessor;
+    }
+
+    public void setXmlTagProcessor(XmlTagProcessor _tagProcessor) {
+        this._tagProcessor = _tagProcessor;
     }
 
     /*
@@ -498,7 +517,7 @@ public class XmlFactory extends JsonFactory
         ctxt.setEncoding(enc);
         return new ToXmlGenerator(ctxt,
                 _generatorFeatures, _xmlGeneratorFeatures,
-                _objectCodec, _createXmlWriter(ctxt, out));
+                _objectCodec, _createXmlWriter(ctxt, out), _tagProcessor);
     }
     
     @Override
@@ -507,7 +526,7 @@ public class XmlFactory extends JsonFactory
         final IOContext ctxt = _createContext(_createContentReference(out), false);
         return new ToXmlGenerator(ctxt,
                 _generatorFeatures, _xmlGeneratorFeatures,
-                _objectCodec, _createXmlWriter(ctxt, out));
+                _objectCodec, _createXmlWriter(ctxt, out), _tagProcessor);
     }
 
     @SuppressWarnings("resource")
@@ -519,7 +538,7 @@ public class XmlFactory extends JsonFactory
         final IOContext ctxt = _createContext(_createContentReference(out), true);
         ctxt.setEncoding(enc);
         return new ToXmlGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
-                _objectCodec, _createXmlWriter(ctxt, out));
+                _objectCodec, _createXmlWriter(ctxt, out), _tagProcessor);
     }
 
     /*
@@ -543,7 +562,7 @@ public class XmlFactory extends JsonFactory
 
         // false -> not managed
         FromXmlParser xp = new FromXmlParser(_createContext(_createContentReference(sr), false),
-                _parserFeatures, _xmlParserFeatures, _objectCodec, sr);
+                _parserFeatures, _xmlParserFeatures, _objectCodec, sr, _tagProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -562,7 +581,7 @@ public class XmlFactory extends JsonFactory
         sw = _initializeXmlWriter(sw);
         IOContext ctxt = _createContext(_createContentReference(sw), false);
         return new ToXmlGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
-                _objectCodec, sw);
+                _objectCodec, sw, _tagProcessor);
     }
 
     /*
@@ -582,7 +601,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr);
+                _objectCodec, sr, _tagProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -600,7 +619,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr);
+                _objectCodec, sr, _tagProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -627,7 +646,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr);
+                _objectCodec, sr, _tagProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -651,7 +670,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr);
+                _objectCodec, sr, _tagProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
@@ -63,6 +63,13 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
      */
     protected ClassLoader _classLoaderForStax;
 
+    /**
+     * See {@link XmlTagProcessor} and {@link XmlTagProcessors}
+     *
+     * @since 2.14
+     */
+    protected XmlTagProcessor _tagProcessor;
+
     /*
     /**********************************************************
     /* Life cycle
@@ -73,6 +80,7 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
         _formatParserFeatures = XmlFactory.DEFAULT_XML_PARSER_FEATURE_FLAGS;
         _formatGeneratorFeatures = XmlFactory.DEFAULT_XML_GENERATOR_FEATURE_FLAGS;
         _classLoaderForStax = null;
+        _tagProcessor = XmlTagProcessors.newPassthroughProcessor();
     }
 
     public XmlFactoryBuilder(XmlFactory base) {
@@ -82,6 +90,7 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
         _xmlInputFactory = base._xmlInputFactory;
         _xmlOutputFactory = base._xmlOutputFactory;
         _nameForTextElement = base._cfgNameForTextElement;
+        _tagProcessor = base._tagProcessor;
         _classLoaderForStax = null;
     }
 
@@ -131,6 +140,10 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
     protected ClassLoader staxClassLoader() {
         return (_classLoaderForStax == null) ?
                 getClass().getClassLoader() : _classLoaderForStax;
+    }
+
+    public XmlTagProcessor xmlTagProcessor() {
+        return _tagProcessor;
     }
 
     // // // Parser features
@@ -251,6 +264,14 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
      */
     public XmlFactoryBuilder staxClassLoader(ClassLoader cl) {
         _classLoaderForStax = cl;
+        return _this();
+    }
+
+    /**
+     * @since 2.14
+     */
+    public XmlFactoryBuilder xmlTagProcessor(XmlTagProcessor tagProcessor) {
+        _tagProcessor = tagProcessor;
         return _this();
     }
     

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
@@ -108,6 +108,14 @@ public class XmlMapper extends ObjectMapper
             _mapper.setDefaultUseWrapper(state);
             return this;
         }
+
+        /**
+         * @since 2.14
+         */
+        public Builder xmlTagProcessor(XmlTagProcessor tagProcessor) {
+            _mapper.setXmlTagProcessor(tagProcessor);
+            return this;
+        }
     }
 
     protected final static JacksonXmlModule DEFAULT_XML_MODULE = new JacksonXmlModule();
@@ -278,6 +286,20 @@ public class XmlMapper extends ObjectMapper
             }
         }
         return this;
+    }
+
+    /**
+     * @since 2.14
+     */
+    public void setXmlTagProcessor(XmlTagProcessor tagProcessor) {
+        ((XmlFactory)_jsonFactory).setXmlTagProcessor(tagProcessor);
+    }
+
+    /**
+     * @since 2.14
+     */
+    public XmlTagProcessor getXmlTagProcessor() {
+        return ((XmlFactory)_jsonFactory).getXmlTagProcessor();
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlTagProcessor.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlTagProcessor.java
@@ -1,0 +1,60 @@
+package com.fasterxml.jackson.dataformat.xml;
+
+import java.io.Serializable;
+
+/**
+ * XML tag name processor primarily used for dealing with tag names
+ * containing invalid characters. Invalid characters in tags can,
+ * for instance, easily appear in map keys.
+ * <p>
+ * Processors should be set in the {@link XmlMapper#setXmlTagProcessor(XmlTagProcessor)}
+ * and/or the {@link XmlMapper.Builder#xmlTagProcessor(XmlTagProcessor)} methods.
+ * <p>
+ * See {@link XmlTagProcessors} for default processors.
+ *
+ * @since 2.14
+ */
+public interface XmlTagProcessor extends Serializable {
+
+    /**
+     * Representation of an XML tag name
+     */
+    class XmlTagName {
+        public final String namespace;
+        public final String localPart;
+
+        public XmlTagName(String namespace, String localPart) {
+            this.namespace = namespace;
+            this.localPart = localPart;
+        }
+    }
+
+
+    /**
+     * Used during XML serialization.
+     * <p>
+     * This method should process the provided {@link XmlTagName} and
+     * escape / encode invalid XML characters.
+     *
+     * @param tag The tag to encode
+     * @return The encoded tag name
+     */
+    XmlTagName encodeTag(XmlTagName tag);
+
+
+    /**
+     * Used during XML deserialization.
+     * <p>
+     * This method should process the provided {@link XmlTagName} and
+     * revert the encoding done in the {@link #encodeTag(XmlTagName)}
+     * method.
+     * <p>
+     * Note: Depending on the use case, it is not always required (or
+     * even possible) to reverse an encoding with 100% accuracy.
+     *
+     * @param tag The tag to encode
+     * @return The encoded tag name
+     */
+    XmlTagName decodeTag(XmlTagName tag);
+
+}

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlTagProcessors.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlTagProcessors.java
@@ -1,0 +1,212 @@
+package com.fasterxml.jackson.dataformat.xml;
+
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Contains default XML tag name processors.
+ * <p>
+ * Processors should be set in the {@link XmlMapper#setXmlTagProcessor(XmlTagProcessor)}
+ * and/or the {@link XmlMapper.Builder#xmlTagProcessor(XmlTagProcessor)} methods.
+ *
+ * @since 2.14
+ */
+public final class XmlTagProcessors {
+
+    /**
+     * Generates a new tag processor that does nothing and just passes through the
+     * tag names. Using this processor may generate invalid XML.
+     * <p>
+     * With this processor set, a map with the keys {@code "123"} and
+     * {@code "$ I am <fancy>! &;"} will be written as:
+     *
+     * <pre>{@code
+     * <DTO>
+     *     <badMap>
+     *         <$ I am <fancy>! &;>xyz</$ I am <fancy>! &;>
+     *         <123>bar</123>
+     *     </badMap>
+     * </DTO>
+     * }</pre>
+     * <p>
+     * This is the default behavior for backwards compatibility.
+     *
+     * @since 2.14
+     */
+    public static XmlTagProcessor newPassthroughProcessor() {
+        return new PassthroughTagProcessor();
+    }
+
+    /**
+     * Generates a new tag processor that replaces all invalid characters in an
+     * XML tag name with a replacement string. This is a one-way processor, since
+     * there is no way to reverse this replacement step.
+     * <p>
+     * With this processor set (and {@code "_"} as the replacement string), a map
+     * with the keys {@code "123"} and {@code "$ I am <fancy>! &;"} will be written as:
+     *
+     * <pre>{@code
+     * <DTO>
+     *     <badMap>
+     *         <__I_am__fancy_____>xyz</__I_am__fancy_____>
+     *         <_23>bar</_23>
+     *     </badMap>
+     * </DTO>
+     * }</pre>
+     *
+     * @param replacement The replacement string to replace invalid characters with
+     *
+     * @since 2.14
+     */
+    public static XmlTagProcessor newReplacementProcessor(String replacement) {
+        return new ReplaceTagProcessor(replacement);
+    }
+
+    /**
+     * Equivalent to calling {@link #newReplacementProcessor(String)} with {@code "_"}
+     *
+     * @since 2.14
+     */
+    public static XmlTagProcessor newReplacementProcessor() {
+        return newReplacementProcessor("_");
+    }
+
+    /**
+     * Generates a new tag processor that escapes all tag names containing invalid
+     * characters with base64. Here the
+     * <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-5">base64url</a>
+     * encoder and decoders are used. The {@code =} padding characters are
+     * always omitted.
+     * <p>
+     * With this processor set, a map with the keys {@code "123"} and
+     * {@code "$ I am <fancy>! &;"} will be written as:
+     *
+     * <pre>{@code
+     * <DTO>
+     *     <badMap>
+     *         <base64_tag_JCBJIGFtIDxmYW5jeT4hICY7>xyz</base64_tag_JCBJIGFtIDxmYW5jeT4hICY7>
+     *         <base64_tag_MTIz>bar</base64_tag_MTIz>
+     *     </badMap>
+     * </DTO>
+     * }</pre>
+     *
+     * @param prefix The prefix to use for tags that are escaped
+     *
+     * @since 2.14
+     */
+    public static XmlTagProcessor newBase64Processor(String prefix) {
+        return new Base64TagProcessor(prefix);
+    }
+
+    /**
+     * Equivalent to calling {@link #newBase64Processor(String)} with {@code "base64_tag_"}
+     *
+     * @since 2.14
+     */
+    public static XmlTagProcessor newBase64Processor() {
+        return newBase64Processor("base64_tag_");
+    }
+
+    /**
+     * Similar to {@link #newBase64Processor(String)}, however, tag names will
+     * <b>always</b> be escaped with base64. No magic prefix is required
+     * for this case, since adding one would be redundant because all tags will
+     * be base64 encoded.
+     */
+    public static XmlTagProcessor newAlwaysOnBase64Processor() {
+        return new AlwaysOnBase64TagProcessor();
+    }
+
+
+
+    private static class PassthroughTagProcessor implements XmlTagProcessor {
+        @Override
+        public XmlTagName encodeTag(XmlTagName tag) {
+            return tag;
+        }
+
+        @Override
+        public XmlTagName decodeTag(XmlTagName tag) {
+            return tag;
+        }
+    }
+
+    private static class ReplaceTagProcessor implements XmlTagProcessor {
+        private static final Pattern BEGIN_MATCHER = Pattern.compile("^[^a-zA-Z_:]");
+        private static final Pattern MAIN_MATCHER = Pattern.compile("[^a-zA-Z0-9_:-]");
+
+        private final String _replacement;
+
+        private ReplaceTagProcessor(String replacement) {
+            _replacement = replacement;
+        }
+
+        @Override
+        public XmlTagName encodeTag(XmlTagName tag) {
+            String newLocalPart = tag.localPart;
+            newLocalPart = BEGIN_MATCHER.matcher(newLocalPart).replaceAll(_replacement);
+            newLocalPart = MAIN_MATCHER.matcher(newLocalPart).replaceAll(_replacement);
+
+            return new XmlTagName(tag.namespace, newLocalPart);
+        }
+
+        @Override
+        public XmlTagName decodeTag(XmlTagName tag) {
+            return tag;
+        }
+    }
+
+    private static class Base64TagProcessor implements XmlTagProcessor {
+        private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
+        private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+        private static final Pattern VALID_XML_TAG = Pattern.compile("[a-zA-Z_:]([a-zA-Z0-9_:.-])*");
+
+        private final String _prefix;
+
+        private Base64TagProcessor(String prefix) {
+            _prefix = prefix;
+        }
+
+        @Override
+        public XmlTagName encodeTag(XmlTagName tag) {
+            if (VALID_XML_TAG.matcher(tag.localPart).matches()) {
+                return tag;
+            }
+            final String encoded = new String(BASE64_ENCODER.encode(tag.localPart.getBytes(UTF_8)), UTF_8);
+            return new XmlTagName(tag.namespace, _prefix + encoded);
+        }
+
+        @Override
+        public XmlTagName decodeTag(XmlTagName tag) {
+            if (!tag.localPart.startsWith(_prefix)) {
+                return tag;
+            }
+            String localName = tag.localPart;
+            localName = localName.substring(_prefix.length());
+            localName = new String(BASE64_DECODER.decode(localName), UTF_8);
+            return new XmlTagName(tag.namespace, localName);
+        }
+    }
+
+    private static class AlwaysOnBase64TagProcessor implements XmlTagProcessor {
+        private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
+        private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+        @Override
+        public XmlTagName encodeTag(XmlTagName tag) {
+            return new XmlTagName(tag.namespace, new String(BASE64_ENCODER.encode(tag.localPart.getBytes(UTF_8)), UTF_8));
+        }
+
+        @Override
+        public XmlTagName decodeTag(XmlTagName tag) {
+            return new XmlTagName(tag.namespace, new String(BASE64_DECODER.decode(tag.localPart), UTF_8));
+        }
+    }
+
+
+    private XmlTagProcessors() {
+        // Nothing to do here
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.core.util.JacksonFeatureSet;
 
 import com.fasterxml.jackson.dataformat.xml.PackageVersion;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlTagProcessor;
+import com.fasterxml.jackson.dataformat.xml.XmlTagProcessors;
 import com.fasterxml.jackson.dataformat.xml.util.CaseInsensitiveNameSet;
 import com.fasterxml.jackson.dataformat.xml.util.StaxUtil;
 
@@ -252,7 +254,7 @@ public class FromXmlParser
      */
 
     public FromXmlParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures,
-            ObjectCodec codec, XMLStreamReader xmlReader)
+             ObjectCodec codec, XMLStreamReader xmlReader, XmlTagProcessor tagProcessor)
         throws IOException
     {
         super(genericParserFeatures);
@@ -261,7 +263,7 @@ public class FromXmlParser
         _objectCodec = codec;
         _parsingContext = XmlReadContext.createRootContext(-1, -1);
         _xmlTokens = new XmlTokenStream(xmlReader, ctxt.contentReference(),
-                    _formatFeatures);
+                    _formatFeatures, tagProcessor);
 
         final int firstToken;
         try {

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -10,6 +10,7 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import com.fasterxml.jackson.dataformat.xml.XmlTagProcessor;
 import org.codehaus.stax2.XMLStreamWriter2;
 import org.codehaus.stax2.ri.Stax2WriterAdapter;
 
@@ -152,6 +153,13 @@ public class ToXmlGenerator
      */
     protected XmlPrettyPrinter _xmlPrettyPrinter;
 
+    /**
+     * Escapes tag names with invalid XML characters
+     *
+     * @since 2.14
+     */
+    protected XmlTagProcessor _tagProcessor;
+
     /*
     /**********************************************************
     /* XML Output state
@@ -205,7 +213,7 @@ public class ToXmlGenerator
      */
 
     public ToXmlGenerator(IOContext ctxt, int stdFeatures, int xmlFeatures,
-            ObjectCodec codec, XMLStreamWriter sw)
+            ObjectCodec codec, XMLStreamWriter sw, XmlTagProcessor tagProcessor)
     {
         super(stdFeatures, codec);
         _formatFeatures = xmlFeatures;
@@ -213,6 +221,7 @@ public class ToXmlGenerator
         _originalXmlWriter = sw;
         _xmlWriter = Stax2WriterAdapter.wrapIfNecessary(sw);
         _stax2Emulation = (_xmlWriter != sw);
+        _tagProcessor = tagProcessor;
         _xmlPrettyPrinter = (_cfgPrettyPrinter instanceof XmlPrettyPrinter) ?
         		(XmlPrettyPrinter) _cfgPrettyPrinter : null;
     }
@@ -476,7 +485,8 @@ public class ToXmlGenerator
         }
         // Should this ever get called?
         String ns = (_nextName == null) ? "" : _nextName.getNamespaceURI();
-        setNextName(new QName(ns, name));
+        XmlTagProcessor.XmlTagName tagName = _tagProcessor.encodeTag(new XmlTagProcessor.XmlTagName(ns, name));
+        setNextName(new QName(tagName.namespace, tagName.localPart));
     }
     
     @Override

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/TagEscapeTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/TagEscapeTest.java
@@ -1,0 +1,118 @@
+package com.fasterxml.jackson.dataformat.xml.misc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlTagProcessors;
+import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class TagEscapeTest extends XmlTestBase {
+
+    public static class DTO {
+        public Map<String, String> badMap = new HashMap<>();
+
+        @Override
+        public String toString() {
+            return "DTO{" +
+                    "badMap=" + badMap.entrySet().stream().map(x -> x.getKey() + "=" + x.getValue()).collect(Collectors.joining(", ", "[", "]")) +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DTO dto = (DTO) o;
+            return Objects.equals(badMap, dto.badMap);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(badMap);
+        }
+    }
+
+    public void testGoodMapKeys() throws JsonProcessingException {
+        DTO dto = new DTO();
+
+        dto.badMap.put("foo", "bar");
+        dto.badMap.put("abc", "xyz");
+
+        XmlMapper mapper = new XmlMapper();
+
+        final String res = mapper.writeValueAsString(dto);
+
+        DTO reversed = mapper.readValue(res, DTO.class);
+
+        assertEquals(dto, reversed);
+    }
+
+    public void testBase64() throws JsonProcessingException {
+        DTO dto = new DTO();
+
+        dto.badMap.put("123", "bar");
+        dto.badMap.put("$ I am <fancy>! &;", "xyz");
+        dto.badMap.put("<!-- No comment=\"but' fancy tag!\"$ />", "xyz");
+
+        XmlMapper mapper = XmlMapper.builder().xmlTagProcessor(XmlTagProcessors.newBase64Processor()).build();
+
+        final String res = mapper.writeValueAsString(dto);
+
+        DTO reversed = mapper.readValue(res, DTO.class);
+
+        assertEquals(dto, reversed);
+    }
+
+    public void testAlwaysOnBase64() throws JsonProcessingException {
+        DTO dto = new DTO();
+
+        dto.badMap.put("123", "bar");
+        dto.badMap.put("$ I am <fancy>! &;", "xyz");
+        dto.badMap.put("<!-- No comment=\"but' fancy tag!\"$ />", "xyz");
+
+        XmlMapper mapper = XmlMapper.builder().xmlTagProcessor(XmlTagProcessors.newAlwaysOnBase64Processor()).build();
+
+        final String res = mapper.writeValueAsString(dto);
+
+        DTO reversed = mapper.readValue(res, DTO.class);
+
+        assertEquals(dto, reversed);
+    }
+
+    public void testReplace() throws JsonProcessingException {
+        DTO dto = new DTO();
+
+        dto.badMap.put("123", "bar");
+        dto.badMap.put("$ I am <fancy>! &;", "xyz");
+        dto.badMap.put("<!-- No comment=\"but' fancy tag!\"$ />", "xyz");
+
+        XmlMapper mapper = XmlMapper.builder().xmlTagProcessor(XmlTagProcessors.newReplacementProcessor()).build();
+
+        final String res = mapper.writeValueAsString(dto);
+
+        DTO reversed = mapper.readValue(res, DTO.class);
+
+        assertNotNull(reversed);
+    }
+
+    public static class BadVarNameDTO {
+        public int $someVar$ = 5;
+    }
+
+    public void testBadVarName() throws JsonProcessingException {
+        BadVarNameDTO dto = new BadVarNameDTO();
+
+        XmlMapper mapper = XmlMapper.builder().xmlTagProcessor(XmlTagProcessors.newBase64Processor()).build();
+
+        final String res = mapper.writeValueAsString(dto);
+
+        BadVarNameDTO reversed = mapper.readValue(res, BadVarNameDTO.class);
+
+        assertEquals(dto.$someVar$, reversed.$someVar$);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlTokenStreamTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlTokenStreamTest.java
@@ -7,6 +7,7 @@ import javax.xml.stream.*;
 import com.fasterxml.jackson.core.io.ContentReference;
 
 import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import com.fasterxml.jackson.dataformat.xml.XmlTagProcessors;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
 import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
 import com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream;
@@ -178,7 +179,7 @@ public class XmlTokenStreamTest extends XmlTestBase
         XMLStreamReader sr = XML_FACTORY.getXMLInputFactory().createXMLStreamReader(new StringReader(doc));
         // must point to START_ELEMENT, so:
         sr.nextTag();
-        XmlTokenStream stream = new XmlTokenStream(sr, ContentReference.rawReference(doc), flags);
+        XmlTokenStream stream = new XmlTokenStream(sr, ContentReference.rawReference(doc), flags, XmlTagProcessors.newPassthroughProcessor());
         stream.initialize();
         return stream;
     }


### PR DESCRIPTION
This commit introduces the `PROCESS_ESCAPED_MALFORMED_TAGS` and
`ESCAPE_MALFORMED_TAGS` features that control whether invalid
tag names will be escaped with an attribute.

fixes #523
fixes #524