### PR TITLE
Removed prolog line feed in XMLPrettyPrinter as the current version m…

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -612,13 +612,6 @@ public class ToXmlGenerator
             // note: since attributes don't nest, can only have one attribute active, so:
             _nextIsAttribute = false;
             _xmlWriter.writeEndElement();
-            // [databind-xml#172]: possibly also need indentation
-            if (_elementNameStack.isEmpty() && (_xmlPrettyPrinter != null)) {
-                // ... but only if it is likely to succeed:
-                if (!_stax2Emulation) {
-                    _xmlPrettyPrinter.writePrologLinefeed(_xmlWriter);
-                }
-            }
         } catch (XMLStreamException e) {
             StaxUtil.throwAsGenerationException(e, this);
         }

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/TextValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/TextValueTest.java
@@ -104,7 +104,7 @@ public class TextValueTest extends XmlTestBase
         assertEquals("<Simple a=\"13\">something</Simple>", xml);
         // [dataformat-xml#56]: should work with indentation as well
         xml = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(new Simple());
-        assertEquals("<Simple a=\"13\">something</Simple>\n", xml);
+        assertEquals("<Simple a=\"13\">something</Simple>", xml);
     }
 
     public void testDeserializeAsText() throws IOException


### PR DESCRIPTION
Removed prolog line feed in XMLPrettyPrinter as the current version mapper doesn't support prolog object mapping