### PR TITLE
Test : Remove hardcoded new line "\n" from tests

### DIFF
--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/XmlTestBase.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/XmlTestBase.java
@@ -20,6 +20,14 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 public abstract class XmlTestBase
     extends TestCase
 {
+
+    protected static final String DEFAULT_NEW_LINE;
+
+    static {
+        String newLine = System.getProperty("line.separator");
+        DEFAULT_NEW_LINE = newLine == null ? "\n" : newLine;
+    }
+
     @JsonPropertyOrder({ "first", "last", "id" })
     protected static class NameBean {
         @JacksonXmlProperty(isAttribute=true)

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/TextValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/misc/TextValueTest.java
@@ -104,7 +104,7 @@ public class TextValueTest extends XmlTestBase
         assertEquals("<Simple a=\"13\">something</Simple>", xml);
         // [dataformat-xml#56]: should work with indentation as well
         xml = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(new Simple());
-        assertEquals("<Simple a=\"13\">something</Simple>\n", xml);
+        assertEquals("<Simple a=\"13\">something</Simple>" + DEFAULT_NEW_LINE, xml);
     }
 
     public void testDeserializeAsText() throws IOException

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/Base64VariantWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/Base64VariantWriteTest.java
@@ -82,7 +82,9 @@ public class Base64VariantWriteTest extends XmlTestBase
             r = r.with(b64v);
         }
         final String EXP = indent ?
-                "<BinaryValue>\n  <value>"+expEncoded+"</value>\n</BinaryValue>" :
+                "<BinaryValue>" + DEFAULT_NEW_LINE +
+                    "  <value>"+expEncoded+"</value>" + DEFAULT_NEW_LINE +
+                    "</BinaryValue>" :
                 "<BinaryValue><value>"+expEncoded+"</value></BinaryValue>";
         final String xml = w.writeValueAsString(new BinaryValue(BINARY_DATA)).trim();
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/XmlPrettyPrinterTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/XmlPrettyPrinterTest.java
@@ -91,8 +91,6 @@ public class XmlPrettyPrinterTest extends XmlTestBase
         _xmlMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
     }
 
-    private static final String SYSTEM_DEFAULT_NEW_LINE = System.getProperty("line.separator");
-
     /*
     /**********************************************************
     /* Unit tests
@@ -159,16 +157,21 @@ public class XmlPrettyPrinterTest extends XmlTestBase
     public void testWithAttr() throws Exception
     {
         String xml = _xmlMapper.writeValueAsString(new AttrBean());
-        assertEquals("<AttrBean count=\"3\"/>\n", xml);
+        assertEquals("<AttrBean count=\"3\"/>" + DEFAULT_NEW_LINE, xml);
         String xml2 = _xmlMapper.writeValueAsString(new AttrBean2());
-        assertEquals("<AttrBean2 count=\"3\">\n  <value>14</value>\n</AttrBean2>\n", xml2);
+        assertEquals(
+            "<AttrBean2 count=\"3\">" + DEFAULT_NEW_LINE +
+            "  <value>14</value>" + DEFAULT_NEW_LINE +
+                "</AttrBean2>" + DEFAULT_NEW_LINE,
+            xml2);
     }
 
     public void testEmptyElem() throws Exception
     {
         PojoFor123 simple = new PojoFor123("foobar");
         String xml = _xmlMapper.writeValueAsString(simple);
-        assertEquals("<PojoFor123 name=\"foobar\"/>\n", xml);
+        assertEquals("<PojoFor123 name=\"foobar\"/>" + DEFAULT_NEW_LINE,
+            xml);
     }
 
     public void testMultiLevel172() throws Exception
@@ -181,15 +184,15 @@ public class XmlPrettyPrinterTest extends XmlTestBase
         // unify possible apostrophes to quotes
         xml = a2q(xml);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + SYSTEM_DEFAULT_NEW_LINE
-                +"<Company>" + SYSTEM_DEFAULT_NEW_LINE
-                +"  <e>" + SYSTEM_DEFAULT_NEW_LINE
-                +"    <employee>" + SYSTEM_DEFAULT_NEW_LINE
-                +"      <id>abc</id>" + SYSTEM_DEFAULT_NEW_LINE
-                +"      <type>FULL_TIME</type>" + SYSTEM_DEFAULT_NEW_LINE
-                +"    </employee>" + SYSTEM_DEFAULT_NEW_LINE
-                +"  </e>" + SYSTEM_DEFAULT_NEW_LINE
-                +"</Company>" + SYSTEM_DEFAULT_NEW_LINE,
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + DEFAULT_NEW_LINE
+                +"<Company>" + DEFAULT_NEW_LINE
+                +"  <e>" + DEFAULT_NEW_LINE
+                +"    <employee>" + DEFAULT_NEW_LINE
+                +"      <id>abc</id>" + DEFAULT_NEW_LINE
+                +"      <type>FULL_TIME</type>" + DEFAULT_NEW_LINE
+                +"    </employee>" + DEFAULT_NEW_LINE
+                +"  </e>" + DEFAULT_NEW_LINE
+                +"</Company>" + DEFAULT_NEW_LINE,
                 xml);
     }
 
@@ -232,15 +235,15 @@ public class XmlPrettyPrinterTest extends XmlTestBase
         xml = a2q(xml);
 
         // with indentation, should get newLines in prolog/epilog too
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + SYSTEM_DEFAULT_NEW_LINE
-                + "<Company>" + SYSTEM_DEFAULT_NEW_LINE
-                + "  <e>" + SYSTEM_DEFAULT_NEW_LINE
-                + "    <employee>" + SYSTEM_DEFAULT_NEW_LINE
-                + "      <id>abc</id>" + SYSTEM_DEFAULT_NEW_LINE
-                + "      <type>FULL_TIME</type>" + SYSTEM_DEFAULT_NEW_LINE
-                + "    </employee>" + SYSTEM_DEFAULT_NEW_LINE
-                + "  </e>" + SYSTEM_DEFAULT_NEW_LINE
-                + "</Company>" + SYSTEM_DEFAULT_NEW_LINE,
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + DEFAULT_NEW_LINE
+                + "<Company>" + DEFAULT_NEW_LINE
+                + "  <e>" + DEFAULT_NEW_LINE
+                + "    <employee>" + DEFAULT_NEW_LINE
+                + "      <id>abc</id>" + DEFAULT_NEW_LINE
+                + "      <type>FULL_TIME</type>" + DEFAULT_NEW_LINE
+                + "    </employee>" + DEFAULT_NEW_LINE
+                + "  </e>" + DEFAULT_NEW_LINE
+                + "</Company>" + DEFAULT_NEW_LINE,
             xml);
     }
 
@@ -255,15 +258,15 @@ public class XmlPrettyPrinterTest extends XmlTestBase
         // unify possible apostrophes to quotes
         xml = a2q(xml);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + SYSTEM_DEFAULT_NEW_LINE
-                + "<Company>" + SYSTEM_DEFAULT_NEW_LINE
-                + "  <e>" + SYSTEM_DEFAULT_NEW_LINE
-                + "    <employee>" + SYSTEM_DEFAULT_NEW_LINE
-                + "      <id>abc</id>" + SYSTEM_DEFAULT_NEW_LINE
-                + "      <type>FULL_TIME</type>" + SYSTEM_DEFAULT_NEW_LINE
-                + "    </employee>" + SYSTEM_DEFAULT_NEW_LINE
-                + "  </e>" + SYSTEM_DEFAULT_NEW_LINE
-                + "</Company>" + SYSTEM_DEFAULT_NEW_LINE,
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + DEFAULT_NEW_LINE
+                + "<Company>" + DEFAULT_NEW_LINE
+                + "  <e>" + DEFAULT_NEW_LINE
+                + "    <employee>" + DEFAULT_NEW_LINE
+                + "      <id>abc</id>" + DEFAULT_NEW_LINE
+                + "      <type>FULL_TIME</type>" + DEFAULT_NEW_LINE
+                + "    </employee>" + DEFAULT_NEW_LINE
+                + "  </e>" + DEFAULT_NEW_LINE
+                + "</Company>" + DEFAULT_NEW_LINE,
             xml);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/XsiNilSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/XsiNilSerializationTest.java
@@ -41,9 +41,8 @@ public class XsiNilSerializationTest extends XmlTestBase
         final String xml = MAPPER.writerWithDefaultPrettyPrinter()
                 .writeValueAsString(new WrapperBean<>(null))
                 .trim();
-        assertEquals(
-"<WrapperBean>\n"
-+"  <value xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>\n"
-+"</WrapperBean>", xml);
+        assertEquals("<WrapperBean>" + DEFAULT_NEW_LINE
+            + "  <value xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>" + DEFAULT_NEW_LINE
+            + "</WrapperBean>", xml);
     }
 }


### PR DESCRIPTION
- Derived from a [suggestion](https://github.com/FasterXML/jackson-dataformat-xml/pull/568#discussion_r1108667498) in merge request **Feature : Allow setting custom linefeed on DefaultXmlPrettyPrinter #568**
- Found some tests that include hard-coded system-default-newlines `"\n"` when the value should actually be read from `System.getProperty("line.separator");`

