### PR TITLE
[DRAFT] deep nesting check

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -686,9 +686,11 @@ public class FromXmlParser
             switch (t) {
             case START_OBJECT:
                 _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                 break;
             case START_ARRAY:
                 _parsingContext = _parsingContext.createChildArrayContext(-1, -1);
+                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                 break;
             case END_OBJECT:
             case END_ARRAY:
@@ -722,6 +724,7 @@ public class FromXmlParser
                 // leave _mayBeLeaf set, as we start a new context
                 _nextToken = JsonToken.FIELD_NAME;
                 _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                 return (_currToken = JsonToken.START_OBJECT);
             }
             if (_parsingContext.inArray()) {
@@ -758,6 +761,7 @@ public class FromXmlParser
                         //    expose as empty Object, not null
                         _nextToken = JsonToken.END_OBJECT;
                         _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                        _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                         return (_currToken = JsonToken.START_OBJECT);
                     }
                     // 07-Sep-2019, tatu: for [dataformat-xml#353], must NOT return second null
@@ -778,6 +782,7 @@ public class FromXmlParser
                     _nextToken = JsonToken.FIELD_NAME;
                     _currText = _xmlTokens.getText();
                     _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                    _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                     return (_currToken = JsonToken.START_OBJECT);
                 }
                 _parsingContext.setCurrentName(_xmlTokens.getLocalName());
@@ -808,6 +813,7 @@ public class FromXmlParser
                                 //    be done, by swallowing the token)
                                 _nextToken = JsonToken.END_OBJECT;
                                 _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                                 return (_currToken = JsonToken.START_OBJECT);
                             }
                         }
@@ -822,6 +828,7 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
                     // START_ELEMENT we just saw:
                     _xmlTokens.pushbackCurrentToken();
                     _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                    _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                 }
                 // [dataformat-xml#177]: empty text may also need to be skipped
                 // but... [dataformat-xml#191]: looks like we can't short-cut, must
@@ -909,6 +916,7 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
             if (_mayBeLeaf) {
                 _nextToken = JsonToken.FIELD_NAME;
                 _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                 _currToken = JsonToken.START_OBJECT;
                 return null;
             }
@@ -949,6 +957,7 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
                 _nextToken = JsonToken.FIELD_NAME;
                 _currText = _xmlTokens.getText();
                 _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
                 _currToken = JsonToken.START_OBJECT;
             } else {
                 _parsingContext.setCurrentName(_xmlTokens.getLocalName());
@@ -987,14 +996,16 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
     }
 
 
-    private void _updateState(JsonToken t)
+    private void _updateState(JsonToken t) throws IOException
     {
         switch (t) {
         case START_OBJECT:
             _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+            _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
             break;
         case START_ARRAY:
             _parsingContext = _parsingContext.createChildArrayContext(-1, -1);
+            _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
             break;
         case END_OBJECT:
         case END_ARRAY:

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -685,12 +685,10 @@ public class FromXmlParser
 
             switch (t) {
             case START_OBJECT:
-                _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                createChildObjectContext(-1, -1);
                 break;
             case START_ARRAY:
-                _parsingContext = _parsingContext.createChildArrayContext(-1, -1);
-                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                createChildArrayContext(-1, -1);
                 break;
             case END_OBJECT:
             case END_ARRAY:
@@ -723,8 +721,7 @@ public class FromXmlParser
             if (_mayBeLeaf) {
                 // leave _mayBeLeaf set, as we start a new context
                 _nextToken = JsonToken.FIELD_NAME;
-                _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                createChildObjectContext(-1, -1);
                 return (_currToken = JsonToken.START_OBJECT);
             }
             if (_parsingContext.inArray()) {
@@ -760,8 +757,7 @@ public class FromXmlParser
                         // 06-Jan-2015, tatu: as per [dataformat-xml#180], need to
                         //    expose as empty Object, not null
                         _nextToken = JsonToken.END_OBJECT;
-                        _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                        _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                        createChildObjectContext(-1, -1);
                         return (_currToken = JsonToken.START_OBJECT);
                     }
                     // 07-Sep-2019, tatu: for [dataformat-xml#353], must NOT return second null
@@ -781,8 +777,7 @@ public class FromXmlParser
                     _mayBeLeaf = false;
                     _nextToken = JsonToken.FIELD_NAME;
                     _currText = _xmlTokens.getText();
-                    _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                    _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                    createChildObjectContext(-1, -1);
                     return (_currToken = JsonToken.START_OBJECT);
                 }
                 _parsingContext.setCurrentName(_xmlTokens.getLocalName());
@@ -812,8 +807,7 @@ public class FromXmlParser
                                 //    expose as empty Object, not null (or, worse, as used to
                                 //    be done, by swallowing the token)
                                 _nextToken = JsonToken.END_OBJECT;
-                                _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                                createChildObjectContext(-1, -1);
                                 return (_currToken = JsonToken.START_OBJECT);
                             }
                         }
@@ -827,8 +821,7 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
                     // fall-through, except must create new context AND push back
                     // START_ELEMENT we just saw:
                     _xmlTokens.pushbackCurrentToken();
-                    _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                    _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                    createChildObjectContext(-1, -1);
                 }
                 // [dataformat-xml#177]: empty text may also need to be skipped
                 // but... [dataformat-xml#191]: looks like we can't short-cut, must
@@ -915,8 +908,7 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
         while (token == XmlTokenStream.XML_START_ELEMENT) {
             if (_mayBeLeaf) {
                 _nextToken = JsonToken.FIELD_NAME;
-                _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                createChildObjectContext(-1, -1);
                 _currToken = JsonToken.START_OBJECT;
                 return null;
             }
@@ -956,8 +948,7 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
                 _mayBeLeaf = false;
                 _nextToken = JsonToken.FIELD_NAME;
                 _currText = _xmlTokens.getText();
-                _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-                _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+                createChildObjectContext(-1, -1);
                 _currToken = JsonToken.START_OBJECT;
             } else {
                 _parsingContext.setCurrentName(_xmlTokens.getLocalName());
@@ -1000,12 +991,10 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
     {
         switch (t) {
         case START_OBJECT:
-            _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
-            _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+            createChildObjectContext(-1, -1);
             break;
         case START_ARRAY:
-            _parsingContext = _parsingContext.createChildArrayContext(-1, -1);
-            _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+            createChildArrayContext(-1, -1);
             break;
         case END_OBJECT:
         case END_ARRAY:
@@ -1434,5 +1423,15 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
         } catch (Exception e) {
             throw new JsonParseException(this, e.getMessage(), e);
         }
+    }
+
+    private void createChildArrayContext(final int lineNr, final int colNr) throws IOException {
+        _parsingContext = _parsingContext.createChildArrayContext(lineNr, colNr);
+        _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
+    }
+
+    private void createChildObjectContext(final int lineNr, final int colNr) throws IOException {
+        _parsingContext = _parsingContext.createChildObjectContext(lineNr, colNr);
+        _streamReadConstraints.validateNestingDepth(_parsingContext.getNestingDepth());
     }
 }

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlReadContext.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlReadContext.java
@@ -66,6 +66,7 @@ public final class XmlReadContext
         _lineNr = lineNr;
         _columnNr = colNr;
         _index = -1;
+        _nestingDepth = parent == null ? 0 : parent._nestingDepth + 1;
     }
 
     protected final void reset(int type, int lineNr, int colNr)

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/dos/DeepNestingParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/dos/DeepNestingParserTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.xml.stream.dos;
 
+import com.ctc.wstx.stax.WstxInputFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -21,6 +22,20 @@ public class DeepNestingParserTest extends XmlTestBase {
             fail("expected JsonParseException");
         } catch (JsonParseException e) {
             assertEquals("Maximum Element Depth limit (1000) Exceeded", e.getMessage());
+        }
+    }
+
+    public void testDeepDocWithCustomDepthLimit() throws Exception
+    {
+        final WstxInputFactory wstxInputFactory = new WstxInputFactory();
+        wstxInputFactory.getConfig().setMaxElementDepth(2000);
+        final XmlMapper xmlMapper = new XmlMapper(wstxInputFactory);
+        final String XML = createDeepNestedDoc(1050);
+        try (JsonParser p = xmlMapper.createParser(XML)) {
+            JsonToken jt;
+            while ((jt = p.nextToken()) != null) {
+
+            }
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/dos/DeepNestingParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/dos/DeepNestingParserTest.java
@@ -1,0 +1,40 @@
+package com.fasterxml.jackson.dataformat.xml.stream.dos;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
+
+public class DeepNestingParserTest extends XmlTestBase {
+
+
+    public void testDeepDoc() throws Exception
+    {
+        final XmlMapper xmlMapper = newMapper();
+        final String XML = createDeepNestedDoc(1050);
+        try (JsonParser p = xmlMapper.createParser(XML)) {
+            JsonToken jt;
+            while ((jt = p.nextToken()) != null) {
+
+            }
+            fail("expected JsonParseException");
+        } catch (JsonParseException e) {
+            assertEquals("Maximum Element Depth limit (1000) Exceeded", e.getMessage());
+        }
+    }
+
+    private String createDeepNestedDoc(final int depth) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<root>");
+        for (int i = 0; i < depth; i++) {
+            sb.append("<leaf>");
+        }
+        sb.append("abc");
+        for (int i = 0; i < depth; i++) {
+            sb.append("</leaf>");
+        }
+        sb.append("</root>");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
relies on https://github.com/FasterXML/jackson-core/pull/943

It may be better to doc that StreamReadConstraints is ignored for jackson-dataformat-xml and that users are better off using WstxInputFactory and creating XmlMapper using an instance of WstxInputFactory.

WstxInputFactory.getConfig() gives you a ReaderConfig which already has a default max element depth of 1000.

https://fasterxml.github.io/woodstox/javadoc/6.0/com/ctc/wstx/api/ReaderConfig.html