### PR TITLE
fail over to factory newInstance for Android support

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/util/StaxUtil.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/util/StaxUtil.java
@@ -126,9 +126,9 @@ public class StaxUtil
         // 05-Jul-2021, tatu: as per [dataformat-xml#483], specify ClassLoader
         try {
             return XMLInputFactory.newFactory(XMLInputFactory.class.getName(), cl);
-        } catch (FactoryConfigurationError e) {
+        } catch (FactoryConfigurationError|NoSuchMethodError e) {
             // 24-Oct-2022, tatu: as per [dataformat-xml#550] need extra care
-            return XMLInputFactory.newFactory();
+            return XMLInputFactory.newInstance();
         }
     }
 
@@ -139,9 +139,9 @@ public class StaxUtil
         // 05-Jul-2021, tatu: as per [dataformat-xml#483], specify ClassLoader
         try {
             return XMLOutputFactory.newFactory(XMLOutputFactory.class.getName(), cl);
-        } catch (FactoryConfigurationError e) {
+        } catch (FactoryConfigurationError|NoSuchMethodError e) {
             // 24-Oct-2022, tatu: as per [dataformat-xml#550] need extra care
-            return XMLOutputFactory.newFactory();
+            return XMLOutputFactory.newInstance();
         }
     }
 


### PR DESCRIPTION
* relates to https://github.com/FasterXML/jackson-dataformat-xml/issues/533
* I don't build Android apps but the original description in #533 seems to indicate that a NoSuchMethodError happens because stax-api jar does not have newFactory methods.