### PR TITLE
Fix handling of null values in string Arrays and Collections

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -932,12 +932,11 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
         switch (token) {
         case XmlTokenStream.XML_END_ELEMENT:
             if (_mayBeLeaf) {
-                // NOTE: this is different from nextToken() -- produce "", NOT null
                 _mayBeLeaf = false;
-                _currToken = JsonToken.VALUE_STRING;
+                _currToken = JsonToken.VALUE_NULL;
                 // 13-May-2020, tatu: [dataformat-xml#397]: advance `index`
                 _parsingContext.valueStarted();
-                return (_currText = "");
+                return (_currText = null);
             }
             _currToken = _parsingContext.inArray() ? JsonToken.END_ARRAY : JsonToken.END_OBJECT;
             _parsingContext = _parsingContext.getParent();

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/StringListRoundtripTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/StringListRoundtripTest.java
@@ -1,0 +1,170 @@
+package com.fasterxml.jackson.dataformat.xml.lists;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import static com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser.Feature.PROCESS_XSI_NIL;
+import static com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator.Feature.WRITE_NULLS_AS_XSI_NIL;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+// [dataformat-xml#584]
+public class StringListRoundtripTest {
+	private final static XmlMapper MAPPER = new XmlMapper();
+
+	@Test
+	public void testStringArray() throws Exception
+	{
+		// default mode, should get back empty string
+		MAPPER.disable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.enable(PROCESS_XSI_NIL);
+		stringArrayRoundtrip(false);
+
+		// xsi null enabled, should get back null
+		MAPPER.enable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.enable(PROCESS_XSI_NIL);
+		stringArrayRoundtrip(true);
+
+		// xsi null write enabled but processing disabled, should get back empty string
+		MAPPER.enable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.disable(PROCESS_XSI_NIL);
+		stringArrayRoundtrip(false);
+	}
+
+	private void stringArrayRoundtrip(boolean shouldBeNull) throws Exception
+	{
+		String[] array = new String[] {"", "test", null, "test2"};
+
+		// serialize to string
+		String xml = MAPPER.writeValueAsString(array);
+		assertNotNull(xml);
+
+		// then bring it back
+		String[] result = MAPPER.readValue(xml, String[].class);
+		assertEquals(4, result.length);
+		assertEquals("", result[0]);
+		assertEquals("test", result[1]);
+		if (shouldBeNull)
+		{
+			assertNull(result[2]);
+		} else
+		{
+			assertEquals("", result[2]);
+		}
+		assertEquals("test2", result[3]);
+	}
+
+	@Test
+	public void testStringList() throws Exception
+	{
+		// default mode, should get back empty string
+		MAPPER.disable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.enable(PROCESS_XSI_NIL);
+		stringListRoundtrip(false);
+
+		// xsi null enabled, should get back null
+		MAPPER.enable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.enable(PROCESS_XSI_NIL);
+		stringListRoundtrip(true);
+
+		// xsi null write enabled but processing disabled, should get back empty string
+		MAPPER.enable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.disable(PROCESS_XSI_NIL);
+		stringListRoundtrip(false);
+	}
+
+	private void stringListRoundtrip(boolean shouldBeNull) throws Exception
+	{
+		List<String> list = asList("", "test", null, "test2");
+
+		// serialize to string
+		String xml = MAPPER.writeValueAsString(list);
+		assertNotNull(xml);
+
+		// then bring it back
+		List<String> result = MAPPER.readValue(xml, new TypeReference<List<String>>() {});
+		assertEquals(4, result.size());
+		assertEquals("", result.get(0));
+		assertEquals("test", result.get(1));
+		if (shouldBeNull)
+		{
+			assertNull(result.get(2));
+		} else
+		{
+			assertEquals("", result.get(2));
+		}
+		assertEquals("test2", result.get(3));
+	}
+
+	@Test
+	public void testStringMap() throws Exception
+	{
+		// default mode, should get back empty string
+		MAPPER.disable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.enable(PROCESS_XSI_NIL);
+		stringMapRoundtrip(false);
+
+		// xsi null enabled, should get back null
+		MAPPER.enable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.enable(PROCESS_XSI_NIL);
+		stringMapRoundtrip(true);
+
+		// xsi null write enabled but processing disabled, should get back empty string
+		MAPPER.enable(WRITE_NULLS_AS_XSI_NIL);
+		MAPPER.disable(PROCESS_XSI_NIL);
+		stringMapRoundtrip(false);
+	}
+
+	private void stringMapRoundtrip(boolean shouldBeNull) throws Exception
+	{
+		Map<String, String> map = new HashMap<String, String>() {{
+			put("a", "");
+			put("b", "test");
+			put("c", null);
+			put("d", "test2");
+		}};
+		MapPojo mapPojo = new MapPojo();
+		mapPojo.setMap( map );
+
+		// serialize to string
+		String xml = MAPPER.writeValueAsString(mapPojo);
+		assertNotNull(xml);
+
+		// then bring it back
+		MapPojo result = MAPPER.readValue(xml, MapPojo.class);
+		assertEquals(4, result.map.size());
+		assertEquals("", result.map.get("a"));
+		assertEquals("test", result.map.get("b"));
+		if (shouldBeNull)
+		{
+			assertNull(result.map.get("c"));
+		} else
+		{
+			assertEquals("", result.map.get("c"));
+		}
+		assertEquals("test2", result.map.get("d"));
+	}
+
+	private static class MapPojo {
+		private Map<String, String> map;
+
+		public MapPojo() {
+		}
+
+		public Map<String, String> getMap() {
+			return map;
+		}
+
+		public void setMap(Map<String, String> map) {
+			this.map = map;
+		}
+	}
+}


### PR DESCRIPTION
Possible fix for https://github.com/FasterXML/jackson-dataformat-xml/issues/584.

As a note, empty and `null` string values in `Map`s were correctly handled even before the change (although requiring the map itself to be wrapped in a POJO). I included a test anyways.