### PR TITLE
police against issues serializing cyclic data

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -536,6 +536,7 @@ public class ToXmlGenerator
     {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext();
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartArray(this);
         } else {
@@ -562,6 +563,7 @@ public class ToXmlGenerator
     {
         _verifyValueWrite("start an object");
         _writeContext = _writeContext.createChildObjectContext();
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartObject(this);
         } else {

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -321,6 +321,11 @@ public class ToXmlGenerator
     /**********************************************************
      */
 
+    @Override
+    public StreamWriteConstraints streamWriteConstraints() {
+        return _ioContext.streamWriteConstraints();
+    }
+
     public ToXmlGenerator enable(Feature f) {
         _formatFeatures |= f.getMask();
         return this;

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/dos/CyclicDataSerTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/dos/CyclicDataSerTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.xml.ser.dos;
 
+import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
@@ -22,8 +23,10 @@ public class CyclicDataSerTest extends XmlTestBase
             MAPPER.writeValueAsString(list);
             fail("expected JsonMappingException");
         } catch (JsonMappingException jmex) {
+            String exceptionPrefix = String.format("Document nesting depth (%d) exceeds the maximum allowed",
+                    StreamWriteConstraints.DEFAULT_MAX_DEPTH + 1);
             assertTrue("JsonMappingException message is as expected?",
-                    jmex.getMessage().startsWith("Document nesting depth (1001) exceeds the maximum allowed"));
+                    jmex.getMessage().startsWith(exceptionPrefix));
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/dos/CyclicDataSerTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/dos/CyclicDataSerTest.java
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.dataformat.xml.ser.dos;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple unit tests to verify that we fail gracefully if you attempt to serialize
+ * data that is cyclic (eg a list that contains itself).
+ */
+public class CyclicDataSerTest extends XmlTestBase
+{
+    private final XmlMapper MAPPER = newMapper();
+
+    public void testListWithSelfReference() throws Exception {
+        List<Object> list = new ArrayList<>();
+        list.add(list);
+        try {
+            MAPPER.writeValueAsString(list);
+            fail("expected JsonMappingException");
+        } catch (JsonMappingException jmex) {
+            assertTrue("JsonMappingException message is as expected?",
+                    jmex.getMessage().startsWith("Document nesting depth (1001) exceeds the maximum allowed"));
+        }
+    }
+}


### PR DESCRIPTION
relates to https://github.com/FasterXML/jackson-core/pull/1055

For deserialization, we rely on Woodstox (or other XML Stream Parser impl) to police the max depth. See https://github.com/FasterXML/jackson-dataformat-xml#usage for how you can configure Woodstox parser (and set the [P_MAX_ELEMENT_DEPTH](http://fasterxml.github.io/woodstox/javadoc/5.0/com/ctc/wstx/api/WstxInputProperties.html#P_MAX_ELEMENT_DEPTH) - default 1000).

Woodstox does not appear to support such a feature for XML writing so jackson-dataformat-xml needs it own code.