### PR TITLE
close IOContext

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -518,6 +518,7 @@ public class FromXmlParser
                 // Also, internal buffer(s) can now be released as well
                 _releaseBuffers();
             }
+            _ioContext.close();
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -1332,42 +1332,45 @@ public class ToXmlGenerator
     @Override
     public void close() throws IOException
     {
+        if (!isClosed()) {
 //        boolean wasClosed = _closed;
-        super.close();
+            super.close();
 
-        // First: let's see that we still have buffers...
-        if (isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
-            try {
-                while (true) {
-		    /* 28-May-2016, tatu: To work around incompatibility introduced by
-		     *     `jackson-core` 2.8 where return type of `getOutputContext()`
-		     *     changed, let's do direct access here.
-		     */
+            // First: let's see that we still have buffers...
+            if (isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
+                try {
+                    while (true) {
+                        /* 28-May-2016, tatu: To work around incompatibility introduced by
+                         *     `jackson-core` 2.8 where return type of `getOutputContext()`
+                         *     changed, let's do direct access here.
+                         */
 //                    JsonStreamContext ctxt = getOutputContext();
-		    JsonStreamContext ctxt = _writeContext;
-                    if (ctxt.inArray()) {
-                        writeEndArray();
-                    } else if (ctxt.inObject()) {
-                        writeEndObject();
-                    } else {
-                        break;
+                        JsonStreamContext ctxt = _writeContext;
+                        if (ctxt.inArray()) {
+                            writeEndArray();
+                        } else if (ctxt.inObject()) {
+                            writeEndObject();
+                        } else {
+                            break;
+                        }
                     }
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    /* 29-Nov-2010, tatu: Stupid, stupid SJSXP doesn't do array checks, so we get
+                     *   hit by this as a collateral problem in some cases. Yuck.
+                     */
+                    throw new JsonGenerationException(e, this);
                 }
-            } catch (ArrayIndexOutOfBoundsException e) {
-                /* 29-Nov-2010, tatu: Stupid, stupid SJSXP doesn't do array checks, so we get
-                 *   hit by this as a collateral problem in some cases. Yuck.
-                 */
-                throw new JsonGenerationException(e, this);
             }
-        }
-        try {
-            if (_ioContext.isResourceManaged() || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET)) {
-                _xmlWriter.closeCompletely();
-            } else {
-                _xmlWriter.close();
+            try {
+                if (_ioContext.isResourceManaged() || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET)) {
+                    _xmlWriter.closeCompletely();
+                } else {
+                    _xmlWriter.close();
+                }
+            } catch (XMLStreamException e) {
+                StaxUtil.throwAsGenerationException(e, this);
             }
-        } catch (XMLStreamException e) {
-            StaxUtil.throwAsGenerationException(e, this);
+            _ioContext.close();
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -138,8 +138,6 @@ public class ToXmlGenerator
      * Stax2 API: this is problematic if trying to use {@link #writeRaw} calls.
      */
     protected final boolean _stax2Emulation;
-    
-    protected final IOContext _ioContext;
 
     /**
      * @since 2.16
@@ -227,9 +225,8 @@ public class ToXmlGenerator
     public ToXmlGenerator(IOContext ctxt, int stdFeatures, int xmlFeatures,
             ObjectCodec codec, XMLStreamWriter sw, XmlNameProcessor nameProcessor)
     {
-        super(stdFeatures, codec);
+        super(stdFeatures, codec, ctxt);
         _formatFeatures = xmlFeatures;
-        _ioContext = ctxt;
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _originalXmlWriter = sw;
         _xmlWriter = Stax2WriterAdapter.wrapIfNecessary(sw);
@@ -1333,8 +1330,6 @@ public class ToXmlGenerator
     public void close() throws IOException
     {
         if (!isClosed()) {
-//        boolean wasClosed = _closed;
-            super.close();
 
             // First: let's see that we still have buffers...
             if (isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
@@ -1370,7 +1365,7 @@ public class ToXmlGenerator
             } catch (XMLStreamException e) {
                 StaxUtil.throwAsGenerationException(e, this);
             }
-            _ioContext.close();
+            super.close();
         }
     }
 


### PR DESCRIPTION
need to close the IOContext now (part of the BufferRecycler changes in v2.16)