### PR TITLE
Fix mismatch in setNextIsUnwrapped(true/false) in XmlBeanSerializerBase#serializeFieldsFiltered()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/XmlBeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/XmlBeanSerializerBase.java
@@ -294,6 +294,11 @@ public abstract class XmlBeanSerializerBase extends BeanSerializerBase
                         filter.serializeAsField(bean, xgen, provider, prop);
                     }
                 }
+                // Reset to avoid next value being written as unwrapped,
+                // for example when property is suppressed
+                if (i == textIndex) {
+                    xgen.setNextIsUnwrapped(false);
+                }
             }
             if (_anyGetterWriter != null) {
                 // For [#117]: not a clean fix, but with @JsonTypeInfo, we'll end up

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationWithFilter.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationWithFilter.java
@@ -1,0 +1,56 @@
+package com.fasterxml.jackson.dataformat.xml.ser;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.PropertyFilter;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+
+/**
+ * Unit test for [PullRequest#616], problems with filtered serialization.
+ */
+public class TestSerializationWithFilter extends XmlTestBase
+{
+    @JsonFilter("filter")
+    static class Item
+    {
+        @JacksonXmlText
+        public int a;
+        public int b;
+        public int c;
+    }
+
+    public void testPullRequest616() throws Exception
+    {
+        Item bean = new Item();
+        bean.a = 0;
+        bean.b = 10;
+        bean.c = 100;
+
+        String exp = "<Item><b>10</b><c>100</c></Item>";
+
+        XmlMapper xmlMapper = new XmlMapper();
+        PropertyFilter filter = new SimpleBeanPropertyFilter() {
+            @Override
+            public void serializeAsField(Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer) throws Exception
+            {
+                if (include(writer) && writer.getName().equals("a")) {
+                    int a = ((Item) pojo).a;
+                    if (a <= 0)
+                        return;
+                }
+                super.serializeAsField(pojo, jgen, provider, writer);
+            }
+        };
+        FilterProvider filterProvider = new SimpleFilterProvider().addFilter("filter", filter);
+        xmlMapper.setFilterProvider(filterProvider);
+        String act = xmlMapper.writeValueAsString(bean);
+        assertEquals(exp, act);
+    }
+}


### PR DESCRIPTION
In serializeFields() of XmlBeanSerializerBase, setNextIsUnwrapped(true) is executed in L.200-203, and setNextIsUnwrapped(false) is executed in L.215-219.
However, in serializeFieldsFiltered(), setNextIsUnwrapped(true) is executed in L.282-285, but there is no corresponding setNextIsUnwrapped(false).