### PR TITLE
Serialize empty tags to actual json array/object

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
@@ -66,6 +66,9 @@ public class XmlFactory extends JsonFactory
 
     protected String _cfgNameForTextElement;
 
+    /**
+     * @since 2.17
+     */
     protected String _cfgValueForEmptyElement;
 
     protected XmlNameProcessor _nameProcessor;
@@ -112,6 +115,9 @@ public class XmlFactory extends JsonFactory
         this(oc, xpFeatures, xgFeatures, xmlIn, xmlOut, nameForTextElem, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE, XmlNameProcessors.newPassthroughProcessor());
     }
 
+    /**
+     * @since 2.17
+     */
     public XmlFactory(ObjectCodec oc, int xpFeatures, int xgFeatures,
                       XMLInputFactory xmlIn, XMLOutputFactory xmlOut,
                       String nameForTextElem, String valueForEmptyElement) {
@@ -248,8 +254,8 @@ public class XmlFactory extends JsonFactory
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
-	return new XmlFactory(_objectCodec, _xmlParserFeatures, _xmlGeneratorFeatures,
-			      inf, outf, _cfgNameForTextElement, _cfgValueForEmptyElement);
+        return new XmlFactory(_objectCodec, _xmlParserFeatures, _xmlGeneratorFeatures,
+                inf, outf, _cfgNameForTextElement, _cfgValueForEmptyElement);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
@@ -66,6 +66,8 @@ public class XmlFactory extends JsonFactory
 
     protected String _cfgNameForTextElement;
 
+    protected String _cfgValueForEmptyElement;
+
     protected XmlNameProcessor _nameProcessor;
     
     /*
@@ -107,18 +109,26 @@ public class XmlFactory extends JsonFactory
     public XmlFactory(ObjectCodec oc, int xpFeatures, int xgFeatures,
                          XMLInputFactory xmlIn, XMLOutputFactory xmlOut,
                          String nameForTextElem) {
-        this(oc, xpFeatures, xgFeatures, xmlIn, xmlOut, nameForTextElem, XmlNameProcessors.newPassthroughProcessor());
+        this(oc, xpFeatures, xgFeatures, xmlIn, xmlOut, nameForTextElem, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE, XmlNameProcessors.newPassthroughProcessor());
+    }
+
+    public XmlFactory(ObjectCodec oc, int xpFeatures, int xgFeatures,
+                      XMLInputFactory xmlIn, XMLOutputFactory xmlOut,
+                      String nameForTextElem, String valueForEmptyElement) {
+        this(oc, xpFeatures, xgFeatures, xmlIn, xmlOut, nameForTextElem, valueForEmptyElement,
+                XmlNameProcessors.newPassthroughProcessor());
     }
 
     protected XmlFactory(ObjectCodec oc, int xpFeatures, int xgFeatures,
             XMLInputFactory xmlIn, XMLOutputFactory xmlOut,
-            String nameForTextElem, XmlNameProcessor nameProcessor)
+            String nameForTextElem, String valueForEmptyElement, XmlNameProcessor nameProcessor)
     {
         super(oc);
         _nameProcessor = nameProcessor;
         _xmlParserFeatures = xpFeatures;
         _xmlGeneratorFeatures = xgFeatures;
         _cfgNameForTextElement = nameForTextElem;
+        _cfgValueForEmptyElement = valueForEmptyElement;
         if (xmlIn == null) {
             xmlIn = StaxUtil.defaultInputFactory(getClass().getClassLoader());
             // as per [dataformat-xml#190], disable external entity expansion by default
@@ -145,6 +155,7 @@ public class XmlFactory extends JsonFactory
         _xmlParserFeatures = src._xmlParserFeatures;
         _xmlGeneratorFeatures = src._xmlGeneratorFeatures;
         _cfgNameForTextElement = src._cfgNameForTextElement;
+        _cfgValueForEmptyElement = src._cfgValueForEmptyElement;
         _xmlInputFactory = src._xmlInputFactory;
         _xmlOutputFactory = src._xmlOutputFactory;
         _nameProcessor = src._nameProcessor;
@@ -161,6 +172,7 @@ public class XmlFactory extends JsonFactory
         _xmlParserFeatures = b.formatParserFeaturesMask();
         _xmlGeneratorFeatures = b.formatGeneratorFeaturesMask();
         _cfgNameForTextElement = b.nameForTextElement();
+        _cfgValueForEmptyElement = b.valueForEmptyElement();
         _xmlInputFactory = b.xmlInputFactory();
         _xmlOutputFactory = b.xmlOutputFactory();
         _nameProcessor = b.xmlNameProcessor();
@@ -237,7 +249,7 @@ public class XmlFactory extends JsonFactory
             throw new IllegalArgumentException(e);
         }
 	return new XmlFactory(_objectCodec, _xmlParserFeatures, _xmlGeneratorFeatures,
-			      inf, outf, _cfgNameForTextElement);
+			      inf, outf, _cfgNameForTextElement, _cfgValueForEmptyElement);
     }
 
     /**
@@ -280,6 +292,20 @@ public class XmlFactory extends JsonFactory
      */
     public String getXMLTextElementName() {
         return _cfgNameForTextElement;
+    }
+
+    /**
+     * @since 2.17
+     */
+    public void setEmptyElementValue(String value) {
+        _cfgValueForEmptyElement = value;
+    }
+
+    /**
+     * @since 2.17
+     */
+    public String getEmptyElementValue() {
+        return _cfgValueForEmptyElement;
     }
     
     /*
@@ -560,7 +586,7 @@ public class XmlFactory extends JsonFactory
 
         // false -> not managed
         FromXmlParser xp = new FromXmlParser(_createContext(_createContentReference(sr), false),
-                _parserFeatures, _xmlParserFeatures, _objectCodec, sr, _nameProcessor);
+                _parserFeatures, _xmlParserFeatures, _objectCodec, sr, _nameProcessor, _cfgValueForEmptyElement);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -599,7 +625,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr, _nameProcessor);
+                _objectCodec, sr, _nameProcessor, _cfgValueForEmptyElement);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -617,7 +643,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr, _nameProcessor);
+                _objectCodec, sr, _nameProcessor, _cfgValueForEmptyElement);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -644,7 +670,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr, _nameProcessor);
+                _objectCodec, sr, _nameProcessor, _cfgValueForEmptyElement);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
@@ -678,7 +704,7 @@ public class XmlFactory extends JsonFactory
         }
         sr = _initializeXmlReader(sr);
         FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
-                _objectCodec, sr, _nameProcessor);
+                _objectCodec, sr, _nameProcessor, _cfgValueForEmptyElement);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
@@ -59,6 +59,10 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
      *<p>
      * Value used for pseudo-property used for returning empty XML tag.
      * Defaults to empty String, but may be changed.
+     *
+     * In case of deserialization/serialization to JSON via JsonNode
+     * and _valueForEmptyElement is equals to [] or {}, the JSON will be serialized
+     * with actual empty json array or object instead of text value ("[]" or "{}")
      */
     protected String _valueForEmptyElement = FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE;
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
@@ -55,7 +55,7 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
     protected String _nameForTextElement;
 
     /**
-     * Set a default value in case of empty an empty element (empty XML tag)
+     * Set a default value in case of an empty element (empty XML tag)
      *<p>
      * Value used for pseudo-property used for returning empty XML tag.
      * Defaults to empty String, but may be changed.

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactoryBuilder.java
@@ -55,6 +55,14 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
     protected String _nameForTextElement;
 
     /**
+     * Set a default value in case of empty an empty element (empty XML tag)
+     *<p>
+     * Value used for pseudo-property used for returning empty XML tag.
+     * Defaults to empty String, but may be changed.
+     */
+    protected String _valueForEmptyElement = FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE;
+
+    /**
      * Optional {@link ClassLoader} to use for constructing
      * {@link XMLInputFactory} and {@kink XMLOutputFactory} instances if
      * not explicitly specified by caller. If not specified, will
@@ -91,6 +99,7 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
         _xmlInputFactory = base._xmlInputFactory;
         _xmlOutputFactory = base._xmlOutputFactory;
         _nameForTextElement = base._cfgNameForTextElement;
+        _valueForEmptyElement = base._cfgValueForEmptyElement;
         _nameProcessor = base._nameProcessor;
         _classLoaderForStax = null;
     }
@@ -101,6 +110,8 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
     public int formatGeneratorFeaturesMask() { return _formatGeneratorFeatures; }
 
     public String nameForTextElement() { return _nameForTextElement; }
+
+    public String valueForEmptyElement() { return _valueForEmptyElement; }
 
     public XMLInputFactory xmlInputFactory() {
         if (_xmlInputFactory == null) {
@@ -210,6 +221,11 @@ public class XmlFactoryBuilder extends TSFBuilder<XmlFactory, XmlFactoryBuilder>
 
     public XmlFactoryBuilder nameForTextElement(String name) {
         _nameForTextElement = name;
+        return _this();
+    }
+
+    public XmlFactoryBuilder valueForEmptyElement(String value) {
+        _valueForEmptyElement = value;
         return _this();
     }
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
@@ -285,6 +285,11 @@ public class XmlMapper extends ObjectMapper
         getFactory().setXMLTextElementName(name);
     }
 
+    // Needed by Builder itself in 2.x, but should not be called by users hence:
+    /**
+     * @deprecated Since 2.17 use {@link Builder#valueForEmptyElement(String)} instead
+     */
+    @Deprecated
     protected void setValueForEmptyElement(String value) {
         getFactory().setEmptyElementValue(value);
     }

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
@@ -104,6 +104,15 @@ public class XmlMapper extends ObjectMapper
             return this;
         }
 
+        /**
+         *
+         * Set a default value in case of an empty element (empty XML tag)
+         *<p>
+         * In case of an empty XML tag (like `<no-content/>`) the serialized value
+         * is set to `String value`. If not specified, the default value is empty String.
+         *
+         * @since 2.17
+         */
         public Builder valueForEmptyElement(String value) {
             _mapper.setValueForEmptyElement(value);
             return this;

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java
@@ -104,6 +104,11 @@ public class XmlMapper extends ObjectMapper
             return this;
         }
 
+        public Builder valueForEmptyElement(String value) {
+            _mapper.setValueForEmptyElement(value);
+            return this;
+        }
+
         public Builder defaultUseWrapper(boolean state) {
             _mapper.setDefaultUseWrapper(state);
             return this;
@@ -269,6 +274,10 @@ public class XmlMapper extends ObjectMapper
     @Deprecated
     protected void setXMLTextElementName(String name) {
         getFactory().setXMLTextElementName(name);
+    }
+
+    protected void setValueForEmptyElement(String value) {
+        getFactory().setEmptyElementValue(value);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -866,6 +866,19 @@ public class FromXmlParser
                     //   expose "XmlText" as separate property
                     token = _nextToken();
 
+                    // Handle JSON object
+                    if (currentValue() == null && _xmlTokens._emptyElement) {
+                        if ("[]".equals(_currText)) {
+                            _nextToken = JsonToken.END_ARRAY;
+                            _parsingContext = _parsingContext.createChildArrayContext(-1, -1);
+                            return (_currToken = JsonToken.START_ARRAY);
+                        } else if ("{}".equals(_currText)) {
+                            _nextToken = JsonToken.END_OBJECT;
+                            _parsingContext = _parsingContext.createChildObjectContext(-1, -1);
+                            return (_currToken = JsonToken.START_OBJECT);
+                        }
+                    }
+
                     if (token == XmlTokenStream.XML_END_ELEMENT) {
                         if (_parsingContext.inArray()) {
                             if (XmlTokenStream._allWs(_currText)) {

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -87,6 +87,19 @@ public class FromXmlParser
         EMPTY_ELEMENT_AS_NULL(false),
 
         /**
+         * Feature that indicates whether XML Empty elements (ones where there are
+         * no separate start and end tags, but just one tag that ends with "/&gt;")
+         * are exposed as {@link JsonToken#START_ARRAY} {@link JsonToken#END_ARRAY}) or not. If they are not
+         * returned as `[]` tokens, they will be returned as {@link JsonToken#VALUE_STRING}
+         * tokens with textual value of "" (empty String).
+         *<p>
+         * Default setting is {@code false}
+         *
+         * @since 2.9
+         */
+        EMPTY_ELEMENT_AS_EMPTY_ARRAY(false),
+
+        /**
          * Feature that indicates whether XML Schema Instance attribute
          * {@code xsi:nil} will be processed automatically -- to indicate {@code null}
          * values -- or not.

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -40,6 +40,10 @@ public class FromXmlParser
      */
     public final static String DEFAULT_UNNAMED_TEXT_PROPERTY = "";
 
+    /**
+     * The default value placeholder for XML empty tag is an empty
+     * String ("").
+     */
     public final static String DEFAULT_EMPTY_ELEMENT_VALUE = "";
 
     /**
@@ -286,6 +290,9 @@ public class FromXmlParser
         this(ctxt, genericParserFeatures, xmlFeatures, codec, xmlReader, tagProcessor, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE);
     }
 
+    /**
+     * @since 2.17
+     */
     public FromXmlParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures,
              ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor, String valueForEmptyElement)
         throws IOException

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -40,6 +40,8 @@ public class FromXmlParser
      */
     public final static String DEFAULT_UNNAMED_TEXT_PROPERTY = "";
 
+    public final static String DEFAULT_EMPTY_ELEMENT_VALUE = "";
+
     /**
      * XML format has some peculiarities, indicated via new (2.12) capability
      * system.
@@ -85,19 +87,6 @@ public class FromXmlParser
          * @since 2.9
          */
         EMPTY_ELEMENT_AS_NULL(false),
-
-        /**
-         * Feature that indicates whether XML Empty elements (ones where there are
-         * no separate start and end tags, but just one tag that ends with "/&gt;")
-         * are exposed as {@link JsonToken#START_ARRAY} {@link JsonToken#END_ARRAY}) or not. If they are not
-         * returned as `[]` tokens, they will be returned as {@link JsonToken#VALUE_STRING}
-         * tokens with textual value of "" (empty String).
-         *<p>
-         * Default setting is {@code false}
-         *
-         * @since 2.9
-         */
-        EMPTY_ELEMENT_AS_EMPTY_ARRAY(false),
 
         /**
          * Feature that indicates whether XML Schema Instance attribute
@@ -171,6 +160,8 @@ public class FromXmlParser
      * @since 2.1
      */
     protected String _cfgNameForTextElement = DEFAULT_UNNAMED_TEXT_PROPERTY;
+
+    protected String _cfgValueForEmptyElement = DEFAULT_EMPTY_ELEMENT_VALUE;
 
     /*
     /**********************************************************
@@ -289,17 +280,25 @@ public class FromXmlParser
      */
 
     public FromXmlParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures,
-             ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor)
+                         ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor)
+            throws IOException
+    {
+        this(ctxt, genericParserFeatures, xmlFeatures, codec, xmlReader, tagProcessor, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE);
+    }
+
+    public FromXmlParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures,
+             ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor, String valueForEmptyElement)
         throws IOException
     {
         super(genericParserFeatures);
+        _cfgValueForEmptyElement = valueForEmptyElement;
         _formatFeatures = xmlFeatures;
         _ioContext = ctxt;
         _streamReadConstraints = ctxt.streamReadConstraints();
         _objectCodec = codec;
         _parsingContext = XmlReadContext.createRootContext(-1, -1);
         _xmlTokens = new XmlTokenStream(xmlReader, ctxt.contentReference(),
-                    _formatFeatures, tagProcessor);
+                    _formatFeatures, _cfgValueForEmptyElement, tagProcessor);
 
         final int firstToken;
         try {
@@ -356,6 +355,13 @@ public class FromXmlParser
      */
     public void setXMLTextElementName(String name) {
         _cfgNameForTextElement = name;
+    }
+
+    /**
+     * @since 2.17
+     */
+    public void setEmptyElementValue(String value) {
+        _cfgValueForEmptyElement = value;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -165,7 +165,14 @@ public class FromXmlParser
      */
     protected String _cfgNameForTextElement = DEFAULT_UNNAMED_TEXT_PROPERTY;
 
-    protected String _cfgValueForEmptyElement = DEFAULT_EMPTY_ELEMENT_VALUE;
+    /**
+     * When an empty element (like {@code <tag/>}) is encountered, this
+     * textual value reported in the token stream: default is empty
+     * String, but may be configured for any other String value.
+     *
+     * @since 2.17
+     */
+    protected final String _cfgValueForEmptyElement;
 
     /*
     /**********************************************************
@@ -283,18 +290,24 @@ public class FromXmlParser
     /**********************************************************
      */
 
+    /**
+     * @deprecated Since 2.17
+     */
+    @Deprecated
     public FromXmlParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures,
-                         ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor)
-            throws IOException
+            ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor)
+        throws IOException
     {
-        this(ctxt, genericParserFeatures, xmlFeatures, codec, xmlReader, tagProcessor, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE);
+        this(ctxt, genericParserFeatures, xmlFeatures, codec, xmlReader, tagProcessor,
+                FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE);
     }
 
     /**
      * @since 2.17
      */
     public FromXmlParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures,
-             ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor, String valueForEmptyElement)
+            ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor,
+            String valueForEmptyElement)
         throws IOException
     {
         super(genericParserFeatures);
@@ -362,13 +375,6 @@ public class FromXmlParser
      */
     public void setXMLTextElementName(String name) {
         _cfgNameForTextElement = name;
-    }
-
-    /**
-     * @since 2.17
-     */
-    public void setEmptyElementValue(String value) {
-        _cfgValueForEmptyElement = value;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -168,12 +168,17 @@ public class XmlTokenStream
     /**********************************************************************
      */
 
+    @Deprecated // since 2.17
     public XmlTokenStream(XMLStreamReader xmlReader, ContentReference sourceRef,
             int formatFeatures, XmlNameProcessor nameProcessor)
     {
-        this(xmlReader, sourceRef, formatFeatures, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE, nameProcessor);
+        this(xmlReader, sourceRef, formatFeatures, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE,
+                nameProcessor);
     }
 
+    /**
+     * @since 2.17
+     */
     public XmlTokenStream(XMLStreamReader xmlReader, ContentReference sourceRef,
             int formatFeatures, String valueForEmptyElement, XmlNameProcessor nameProcessor)
     {

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import javax.xml.XMLConstants;
 import javax.xml.stream.*;
 
-import com.fasterxml.jackson.core.JsonToken;
 import org.codehaus.stax2.XMLStreamLocation2;
 import org.codehaus.stax2.XMLStreamReader2;
 
@@ -121,6 +120,8 @@ public class XmlTokenStream
      */
     protected String _textValue;
 
+    protected String _valueForEmptyElement;
+
     /**
      * Marker flag set if caller wants to "push back" current token so
      * that next call to {@link #next()} should simply be given what was
@@ -170,6 +171,12 @@ public class XmlTokenStream
     public XmlTokenStream(XMLStreamReader xmlReader, ContentReference sourceRef,
             int formatFeatures, XmlNameProcessor nameProcessor)
     {
+        this(xmlReader, sourceRef, formatFeatures, FromXmlParser.DEFAULT_EMPTY_ELEMENT_VALUE, nameProcessor);
+    }
+
+    public XmlTokenStream(XMLStreamReader xmlReader, ContentReference sourceRef,
+            int formatFeatures, String valueForEmptyElement, XmlNameProcessor nameProcessor)
+    {
         _sourceReference = sourceRef;
         _formatFeatures = formatFeatures;
         _cfgProcessXsiNil = FromXmlParser.Feature.PROCESS_XSI_NIL.enabledIn(_formatFeatures);
@@ -177,6 +184,7 @@ public class XmlTokenStream
         // 04-Dec-2023, tatu: [dataformat-xml#618] Need further customized adapter:
         _xmlReader = Stax2JacksonReaderAdapter.wrapIfNecessary(xmlReader);
         _nameProcessor = nameProcessor;
+        _valueForEmptyElement = valueForEmptyElement;
     }
 
     /**
@@ -561,10 +569,7 @@ public class XmlTokenStream
             if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
                 return null;
             }
-            if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_EMPTY_ARRAY.enabledIn(_formatFeatures)) {
-                return JsonToken.START_ARRAY.asString() + JsonToken.END_ARRAY.asString();
-            }
-            return "";
+            return _valueForEmptyElement;
         }
 
         CharSequence chars = null;

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.xml.XMLConstants;
 import javax.xml.stream.*;
 
+import com.fasterxml.jackson.core.JsonToken;
 import org.codehaus.stax2.XMLStreamLocation2;
 import org.codehaus.stax2.XMLStreamReader2;
 
@@ -549,6 +550,7 @@ public class XmlTokenStream
 
     /**
      * @return Collected text, if any, EXCEPT that if {@code FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL}
+     *    OR {@code FromXmlParser.Feature.EMPTY_ELEMENT_AS_EMPTY_ARRAY}
      *    AND empty element, returns {@code null}
      */
     private final String _collectUntilTag() throws XMLStreamException
@@ -558,6 +560,9 @@ public class XmlTokenStream
             _xmlReader.next();
             if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
                 return null;
+            }
+            if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_EMPTY_ARRAY.enabledIn(_formatFeatures)) {
+                return JsonToken.START_ARRAY.asString() + JsonToken.END_ARRAY.asString();
             }
             return "";
         }

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -120,7 +120,7 @@ public class XmlTokenStream
      */
     protected String _textValue;
 
-    protected String _valueForEmptyElement;
+    protected final String _valueForEmptyElement;
 
     /**
      * Marker flag set if caller wants to "push back" current token so
@@ -558,7 +558,6 @@ public class XmlTokenStream
 
     /**
      * @return Collected text, if any, EXCEPT that if {@code FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL}
-     *    OR {@code FromXmlParser.Feature.EMPTY_ELEMENT_AS_EMPTY_ARRAY}
      *    AND empty element, returns {@code null}
      */
     private final String _collectUntilTag() throws XMLStreamException

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -123,6 +123,11 @@ public class XmlTokenStream
     protected final String _valueForEmptyElement;
 
     /**
+     * true if the current tag is empty
+     */
+    protected boolean _emptyElement;
+
+    /**
      * Marker flag set if caller wants to "push back" current token so
      * that next call to {@link #next()} should simply be given what was
      * already read.
@@ -190,6 +195,7 @@ public class XmlTokenStream
         _xmlReader = Stax2JacksonReaderAdapter.wrapIfNecessary(xmlReader);
         _nameProcessor = nameProcessor;
         _valueForEmptyElement = valueForEmptyElement;
+        _emptyElement = false;
     }
 
     /**
@@ -569,6 +575,7 @@ public class XmlTokenStream
     {
         // 21-Jun-2017, tatu: Whether exposed as `null` or "" is now configurable...
         if (_xmlReader.isEmptyElement()) {
+            _emptyElement = true;
             _xmlReader.next();
             if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
                 return null;
@@ -576,6 +583,7 @@ public class XmlTokenStream
             return _valueForEmptyElement;
         }
 
+        _emptyElement = false;
         CharSequence chars = null;
         main_loop:
         while (_xmlReader.hasNext()) {

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -103,6 +105,42 @@ public class EmptyStringValueTest extends XmlTestBase
         assertNotNull(name);
         assertEquals("[]", name.first);
         assertEquals("", name.last);
+    }
+
+    public void testEmptyElementFromXmlToJsonArray() throws Exception
+    {
+        final String xml = "<name><first/><last>[]</last></name>";
+
+        XmlMapper xmlMapper = XmlMapper.builder()
+                .valueForEmptyElement("[]")
+                .build();
+        JsonNode jsonNode = xmlMapper.readValue(xml, JsonNode.class);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(jsonNode);
+
+        // first is an empty tag, and is expected to be serialized
+        // as an empty json array, last is not empty, and is serialized as text value
+        String expectedJson = "{\"first\":[],\"last\":\"[]\"}";
+        assertEquals(expectedJson, json);
+    }
+
+    public void testEmptyElementFromXmlToJsonObject() throws Exception
+    {
+        final String xml = "<name><first/><last>{}</last></name>";
+
+        XmlMapper xmlMapper = XmlMapper.builder()
+                .valueForEmptyElement("{}")
+                .build();
+        JsonNode jsonNode = xmlMapper.readValue(xml, JsonNode.class);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(jsonNode);
+
+        // first is an empty tag, and is expected to be serialized
+        // as an empty json object, last is not empty, and is serialized as text value
+        String expectedJson = "{\"first\":{},\"last\":\"{}\"}";
+        assertEquals(expectedJson, json);
     }
 
     public void testEmptyStringElement() throws Exception

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
@@ -97,7 +97,7 @@ public class EmptyStringValueTest extends XmlTestBase
 
         // but can be changed
         XmlMapper mapper2 = XmlMapper.builder()
-                .enable(FromXmlParser.Feature.EMPTY_ELEMENT_AS_EMPTY_ARRAY)
+                .valueForEmptyElement("[]")
                 .build();
         name = mapper2.readValue(XML, Name.class);
         assertNotNull(name);

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
@@ -85,6 +85,26 @@ public class EmptyStringValueTest extends XmlTestBase
         assertEquals("", name.last);
     }
 
+    public void testEmptyElementEmptyArray() throws Exception
+    {
+        final String XML = "<name><first/><last></last></name>";
+
+        // Default settings (since 2.12): empty element does NOT become `null`:
+        Name name = MAPPER.readValue(XML, Name.class);
+        assertNotNull(name);
+        assertEquals("", name.first);
+        assertEquals("", name.last);
+
+        // but can be changed
+        XmlMapper mapper2 = XmlMapper.builder()
+                .enable(FromXmlParser.Feature.EMPTY_ELEMENT_AS_EMPTY_ARRAY)
+                .build();
+        name = mapper2.readValue(XML, Name.class);
+        assertNotNull(name);
+        assertEquals("[]", name.first);
+        assertEquals("", name.last);
+    }
+
     public void testEmptyStringElement() throws Exception
     {
         // then with empty element

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlTokenStreamTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlTokenStreamTest.java
@@ -181,7 +181,8 @@ public class XmlTokenStreamTest extends XmlTestBase
         XMLStreamReader sr = XML_FACTORY.getXMLInputFactory().createXMLStreamReader(new StringReader(doc));
         // must point to START_ELEMENT, so:
         sr.nextTag();
-        XmlTokenStream stream = new XmlTokenStream(sr, ContentReference.rawReference(doc), flags, XmlNameProcessors.newPassthroughProcessor());
+        XmlTokenStream stream = new XmlTokenStream(sr, ContentReference.rawReference(doc), flags,
+                "", XmlNameProcessors.newPassthroughProcessor());
         stream.initialize();
         return stream;
     }


### PR DESCRIPTION
Hello @cowtowncoder , I think it would be nice to serialize empty tag into actual array/objects (in some cases), not text value, in particular, as you can see from the added test case `<name><first/><last>[]</last></name>` will be serialized as `{"first":[],"last":"[]"}` when using JsonNode, the empty tag first is serialized as an empty json array, not a text value.

But I feel like that my [solution](https://github.com/FasterXML/jackson-dataformat-xml/compare/2.17...Croway:json-array-serialize?expand=1#diff-654673c980213587a428541c0914c8096fe61324d9852688d7b04853fa277b45R870) is a bit hacky, do you have any hint?

Once https://github.com/FasterXML/jackson-dataformat-xml/pull/640 is merged I'll rebase this one.