### PR TITLE
Modify `surefire plugin` failing test scope 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,6 @@ alternative support for serializing POJOs as XML and deserializing XML as pojos.
           <version>${version.plugin.surefire}</version>
           <configuration>
             <excludes>
-              <exclude>com/fasterxml/jackson/dataformat/xml/failing/*.java</exclude>
               <exclude>**/failing/**/*.java</exclude>
             </excludes>
             <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@ alternative support for serializing POJOs as XML and deserializing XML as pojos.
           <configuration>
             <excludes>
               <exclude>com/fasterxml/jackson/dataformat/xml/failing/*.java</exclude>
+              <exclude>**/failing/**/*.java</exclude>
             </excludes>
             <includes>
               <include>**/Test*.java</include>


### PR DESCRIPTION
We are starting to follow `databind` module's test structure and this is what databind module used to have.
We need current change for `..../records/failing` test directory

Note : Ironically databind module went even further with recent [failing test handling improvement ](https://github.com/FasterXML/jackson-databind/pull/4696), but we need to upgrade to JUnit 5 to achieve that.