### PR TITLE
[`master`] fix failing tests after `FAIL_ON_NULL_FOR_PRIMITIVES` to `true` [databind#4890]

### DIFF
--- a/src/test/java/tools/jackson/dataformat/xml/deser/EmptyWithScalarsTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/EmptyWithScalarsTest.java
@@ -43,7 +43,9 @@ public class EmptyWithScalarsTest extends XmlTestBase
         public Boolean B = Boolean.TRUE;
     }
 
-    private final XmlMapper MAPPER = newMapper();
+    private final XmlMapper MAPPER = mapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
 
     /*
     /**********************************************************************


### PR DESCRIPTION
Resolves failing tests affected by https://github.com/FasterXML/jackson-databind/issues/4858