### PR TITLE
fix test imports (jupiter)

### DIFF
--- a/src/test-jdk17/java/com/fasterxml/jackson/dataformat/xml/jdk17/Java17CollectionsTest.java
+++ b/src/test-jdk17/java/com/fasterxml/jackson/dataformat/xml/jdk17/Java17CollectionsTest.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.dataformat.xml.jdk17;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -11,6 +13,7 @@ public class Java17CollectionsTest extends XmlTestBase
 {
     private final XmlMapper _xmlMapper = new XmlMapper();
 
+    @Test
     public void testStreamOf()
             throws Exception
     {

--- a/src/test-jdk17/java/com/fasterxml/jackson/dataformat/xml/records/failing/XmlWrapperRecord517Test.java
+++ b/src/test-jdk17/java/com/fasterxml/jackson/dataformat/xml/records/failing/XmlWrapperRecord517Test.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
 // [databind#517] XML wrapper doesn't work with java records
 // Equivalent to on in jdk17/.../deser/XmlWrapperRecord517Test.java
@@ -42,6 +43,7 @@ public class XmlWrapperRecord517Test
                     "</messages>" +
                 "</Request>";
 
+    @JacksonTestFailureExpected
     @Test
     public void testWrapper() throws Exception {
         XmlWrapperRecord517Test.Request request = new Request(List.of(new Message("Hello, World!")));

--- a/src/test-jdk17/java/com/fasterxml/jackson/dataformat/xml/records/failing/XmlWrapperRecord517Test.java
+++ b/src/test-jdk17/java/com/fasterxml/jackson/dataformat/xml/records/failing/XmlWrapperRecord517Test.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.dataformat.xml.records.failing;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/StringListRoundtripTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/lists/StringListRoundtripTest.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.dataformat.xml.lists;
 
 import java.util.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import static com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser.Feature.PROCESS_XSI_NIL;
 import static com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator.Feature.WRITE_NULLS_AS_XSI_NIL;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 // [dataformat-xml#584]
 public class StringListRoundtripTest


### PR DESCRIPTION
This is a bug fix because tests that use the org.junit.Test annotation no longer seem to run.

See #736 