### PR TITLE
run jdk17 tests on all Java versions 17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,10 +210,10 @@ alternative support for serializing POJOs as XML and deserializing XML as POJOs.
 
   <profiles>
     <profile>
-      <!-- And different set up for JDK 17 -->
+      <!-- And different set up for JDK 17 and above -->
       <id>java17</id>
       <activation>
-        <jdk>17</jdk>
+        <jdk>[17, )</jdk>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
current maven setup means JDK17 tests are not run when we test with Java 21 - only when Java version is exactly 17.