### PR TITLE
add test for issue 734 (disabled)

### DIFF
--- a/src/test/java/tools/jackson/dataformat/xml/tofix/records/XmlRecordDeser734Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/tofix/records/XmlRecordDeser734Test.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -12,21 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class XmlRecordDeser734Test extends XmlTestUtil
 {
 
-    record Amount(@JacksonXmlProperty String value,
+    record Amount(@JacksonXmlText String value,
                   @JacksonXmlProperty(isAttribute = true, localName = "Ccy") String currency) {}
 
     private final String XML =
             a2q("<Amt Ccy='EUR'>1</Amt>");
 
+    @JacksonTestFailureExpected
     @Test
     public void testDeser() throws Exception {
         XmlMapper mapper = new XmlMapper();
-        Amount amt0 = new Amount("1", "EUR");
-        String xml0 = mapper.writeValueAsString(amt0);
-        assertEquals(XML, xml0);
         Amount amt = mapper.readValue(XML, Amount.class);
-        // on master, the next assert fails because the value is null
-        assertEquals(1, amt.value);
+        assertEquals("1", amt.value);
         assertEquals("EUR", amt.currency);
     }
 }

--- a/src/test/java/tools/jackson/dataformat/xml/tofix/records/XmlRecordDeser734Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/tofix/records/XmlRecordDeser734Test.java
@@ -1,0 +1,32 @@
+package tools.jackson.dataformat.xml.tofix.records;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// [dataformat-xml#734]
+public class XmlRecordDeser734Test extends XmlTestUtil
+{
+
+    record Amount(@JacksonXmlProperty String value,
+                  @JacksonXmlProperty(isAttribute = true, localName = "Ccy") String currency) {}
+
+    private final String XML =
+            a2q("<Amt Ccy='EUR'>1</Amt>");
+
+    @Test
+    public void testDeser() throws Exception {
+        XmlMapper mapper = new XmlMapper();
+        Amount amt0 = new Amount("1", "EUR");
+        String xml0 = mapper.writeValueAsString(amt0);
+        assertEquals(XML, xml0);
+        Amount amt = mapper.readValue(XML, Amount.class);
+        // on master, the next assert fails because the value is null
+        assertEquals(1, amt.value);
+        assertEquals("EUR", amt.currency);
+    }
+}


### PR DESCRIPTION
@cowtowncoder this seems to reproduce the issue in #734 

I targeted master because of the build issues in 2.19 branch - #737 (etc)

When enabled, I get
```
[ERROR] Errors: 
[ERROR]   XmlRecordDeser734Test.testDeser:25 » InvalidDefinition Invalid definition for property '' (of type `tools.jackson.dataformat.xml.tofix.records.XmlRecordDeser734Test$Amount`): Could not find creator property with name '' (known Creator properties: [value, Ccy])
 at [Source: (String)"<Amt Ccy="EUR">1</Amt>"; line: 1, column: 1]
```