### PR TITLE
Add feature to include `standalone='yes'` in xml declaration

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -271,3 +271,8 @@ Bas Passon (@bpasson)
 * Reported, contributed fix for #646: Deserializing fails when using builder classes
   with `Iterable` Collection setters
  (2.17.1)
+
+多多冰冰 (@duoduobingbing)
+
+* Contributed #745: Add feature to include `standalone='yes'` in xml declaration
+ (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,7 +4,10 @@ Project: jackson-dataformat-xml
 === Releases ===
 ------------------------------------------------------------------------
 
-2.19.0-rc (07-Apr-2025)
+#745: Add feature to include `standalone='yes'` in xml declaration
+ (contributed by @duoduobingbing)
+
+2.19.0-rc2 (07-Apr-2025)
 
 #700: Unify testing structure/tools [JSTEP-10]
  (fix contributed by Joo Hyuk K)

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -52,6 +52,15 @@ public class ToXmlGenerator
         WRITE_XML_DECLARATION(false),
 
         /**
+         * Feature that controls whether XML declaration should include the standalone attribute
+         * when generator is initialized (true) or not (false). Only honored when
+         * {@link Feature#WRITE_XML_DECLARATION WRITE_XML_DECLARATION} is enabled
+         *
+         * @since 2.19
+         */
+        WRITE_STANDALONE_YES_TO_XML_DECLARATION(false),
+
+        /**
          * Feature that controls whether output should be done as XML 1.1; if so,
          * certain aspects may differ from default (1.0) processing: for example,
          * XML declaration will be automatically added (regardless of setting
@@ -297,15 +306,24 @@ public class ToXmlGenerator
         _initialized = true;
         try {
             boolean xmlDeclWritten;
-            if (Feature.WRITE_XML_1_1.enabledIn(_formatFeatures)) {
-                _xmlWriter.writeStartDocument("UTF-8", "1.1");
-                xmlDeclWritten = true;
-            } else if (Feature.WRITE_XML_DECLARATION.enabledIn(_formatFeatures)) {
-                _xmlWriter.writeStartDocument("UTF-8", "1.0");
+
+            if (Feature.WRITE_XML_1_1.enabledIn(_formatFeatures) ||
+                    Feature.WRITE_XML_DECLARATION.enabledIn(_formatFeatures)) {
+
+                String xmlVersion = Feature.WRITE_XML_1_1.enabledIn(_formatFeatures) ? "1.1" : "1.0";
+                String encoding = "UTF-8";
+
+                if (Feature.WRITE_STANDALONE_YES_TO_XML_DECLARATION.enabledIn(_formatFeatures)) {
+                    _xmlWriter.writeStartDocument(xmlVersion, encoding, true);
+                } else {
+                    _xmlWriter.writeStartDocument(encoding, xmlVersion);
+                }
+
                 xmlDeclWritten = true;
             } else {
                 xmlDeclWritten = false;
             }
+
             // as per [dataformat-xml#172], try adding indentation
             if (xmlDeclWritten && (_xmlPrettyPrinter != null)) {
                 // ... but only if it is likely to succeed:

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestXmlDeclaration.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestXmlDeclaration.java
@@ -32,5 +32,26 @@ public class TestXmlDeclaration extends XmlTestUtil
         String xml = mapper.writeValueAsString(new StringBean("abcd"));
         assertEquals(xml, "<?xml version='1.1' encoding='UTF-8'?><StringBean><text>abcd</text></StringBean>");
     }
+
+    @Test
+    public void testXml11DeclarationWithStandalone() throws Exception
+    {
+        XmlMapper mapper = new XmlMapper();
+        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_1_1, true);
+        mapper.configure(ToXmlGenerator.Feature.WRITE_STANDALONE_YES_TO_XML_DECLARATION, true);
+        String xml = mapper.writeValueAsString(new StringBean("abcd"));
+        assertEquals("<?xml version='1.1' encoding='UTF-8' standalone='yes'?><StringBean><text>abcd</text></StringBean>", xml);
+    }
+
+    @Test
+    public void testXml10DeclarationWithStandalone() throws Exception
+    {
+        XmlMapper mapper = new XmlMapper();
+        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        mapper.configure(ToXmlGenerator.Feature.WRITE_STANDALONE_YES_TO_XML_DECLARATION, true);
+        String xml = mapper.writeValueAsString(new StringBean("abcd"));
+        assertEquals("<?xml version='1.0' encoding='UTF-8' standalone='yes'?><StringBean><text>abcd</text></StringBean>", xml);
+    }
     
 }


### PR DESCRIPTION
By default there is no easy way with Jackson XML to include `standalone='yes'` inside the XML declaration. It requires swapping out the `xmlWriter` which is really cumbersome because the implementations of `BaseStreamWriter` from Woodstox are final like `RepairingNsStreamWriter`. Hence to change this the entirety of e.g. `RepairingNsStreamWriter` needs to be copied to the project only to override `BaseStreamWriter#writeStartDocument` to call `doWriteStartDocument(version, encoding, "yes");` instead of the default `doWriteStartDocument(version, encoding, null);`.

This PR adds `ToXmlGenerator.Feature.WRITE_STANDALONE_YES_TO_XML_DECLARATION` which is `false` by default.

When enabled `standalone='yes'` will be added to the XML declaration if including it is enabled as well: 
```java
XmlMapper mapper = new XmlMapper();
mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
mapper.configure(ToXmlGenerator.Feature.WRITE_STANDALONE_YES_TO_XML_DECLARATION, true);
String xml = mapper.writeValueAsString(Map.of("abc","def"));
```
will cause the first line to have<br>
`<?xml version='1.0' encoding='UTF-8' standalone='yes'?>`

There is definetely a need for this as demonstrated by these posts:
* https://stackoverflow.com/questions/74195415/springboot-jackson-2-13-x-outputting-standalone-yes-in-xml-header
* https://stackoverflow.com/questions/52999562/add-standalone-directive-to-jackson-xml-serialization
* https://www.mail-archive.com/jackson-dev@googlegroups.com/msg00345.html