### PR TITLE
Naive attempt at fixing #306

### DIFF
--- a/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
@@ -8,7 +8,6 @@ import tools.jackson.databind.PropertyName;
 import tools.jackson.databind.cfg.MapperConfig;
 import tools.jackson.databind.introspect.*;
 import tools.jackson.dataformat.xml.annotation.*;
-import tools.jackson.dataformat.xml.deser.FromXmlParser;
 
 /**
  * Extension of {@link JacksonAnnotationIntrospector} that is needed to support
@@ -38,12 +37,19 @@ public class JacksonXmlAnnotationIntrospector
 
     protected boolean _cfgDefaultUseWrapper;
 
+    protected final JacksonXmlAnnotationIntrospectorConfig _cfgIntrospectorConfig;
+
     public JacksonXmlAnnotationIntrospector() {
         this(DEFAULT_USE_WRAPPER);
     }
 
     public JacksonXmlAnnotationIntrospector(boolean defaultUseWrapper) {
+        this(defaultUseWrapper, new JacksonXmlAnnotationIntrospectorConfig());
+    }
+
+    public JacksonXmlAnnotationIntrospector(boolean defaultUseWrapper, JacksonXmlAnnotationIntrospectorConfig introspectorConfig) {
         _cfgDefaultUseWrapper = defaultUseWrapper;
+        _cfgIntrospectorConfig = introspectorConfig;
     }
 
     /*
@@ -85,7 +91,7 @@ public class JacksonXmlAnnotationIntrospector
         }
         return null;
     }
-    
+
     @SuppressWarnings("deprecation")
     @Override
     public PropertyName findRootName(MapperConfig<?> config, AnnotatedClass ac)
@@ -94,7 +100,7 @@ public class JacksonXmlAnnotationIntrospector
         if (root != null) {
             String local = root.localName();
             String ns = root.namespace();
-            
+
             if (local.length() == 0 && ns.length() == 0) {
                 return PropertyName.USE_DEFAULT;
             }
@@ -209,8 +215,11 @@ public class JacksonXmlAnnotationIntrospector
         PropertyName pn = PropertyName.merge(_findXmlName(a),
                 super.findNameForDeserialization(config, a));
         if (pn == null) {
-            if(_hasAnnotation(a, JacksonXmlText.class)){
-                return PropertyName.construct(FromXmlParser.DEFAULT_TEXT_PROPERTY);
+            JacksonXmlText jacksonXmlTextAnnotation = _findAnnotation(a, JacksonXmlText.class);
+
+            if (jacksonXmlTextAnnotation != null && jacksonXmlTextAnnotation.value() &&
+                !_cfgIntrospectorConfig.inferXmlTextPropertyName()) {
+                return _cfgIntrospectorConfig.xmlTextPropertyName();
             }
 
             if (_hasOneOf(a, ANNOTATIONS_TO_INFER_XML_PROP)) {

--- a/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
@@ -8,6 +8,7 @@ import tools.jackson.databind.PropertyName;
 import tools.jackson.databind.cfg.MapperConfig;
 import tools.jackson.databind.introspect.*;
 import tools.jackson.dataformat.xml.annotation.*;
+import tools.jackson.dataformat.xml.deser.FromXmlParser;
 
 /**
  * Extension of {@link JacksonAnnotationIntrospector} that is needed to support
@@ -208,6 +209,10 @@ public class JacksonXmlAnnotationIntrospector
         PropertyName pn = PropertyName.merge(_findXmlName(a),
                 super.findNameForDeserialization(config, a));
         if (pn == null) {
+            if(_hasAnnotation(a, JacksonXmlText.class)){
+                return PropertyName.construct(FromXmlParser.DEFAULT_TEXT_PROPERTY);
+            }
+
             if (_hasOneOf(a, ANNOTATIONS_TO_INFER_XML_PROP)) {
                 return PropertyName.USE_DEFAULT;
             }

--- a/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospectorConfig.java
+++ b/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospectorConfig.java
@@ -1,0 +1,28 @@
+package tools.jackson.dataformat.xml;
+
+import tools.jackson.databind.PropertyName;
+import tools.jackson.dataformat.xml.deser.FromXmlParser;
+
+import java.io.Serializable;
+
+public record JacksonXmlAnnotationIntrospectorConfig(
+        boolean inferXmlTextPropertyName,
+        PropertyName xmlTextPropertyName //Only honored if inferXmlTextPropertyName is false
+) implements Serializable {
+
+    /**
+     * Constructs a JacksonXmlAnnotationIntrospectorConfig with the default configuration
+     * Does not infer the XmlTextPropertyName by default and uses {@link FromXmlParser#DEFAULT_TEXT_PROPERTY} for the {@link PropertyName}.
+     */
+    public JacksonXmlAnnotationIntrospectorConfig() {
+        this(false, PropertyName.construct(FromXmlParser.DEFAULT_TEXT_PROPERTY));
+    }
+
+    public JacksonXmlAnnotationIntrospectorConfig withInferXmlTextPropertyName(boolean inferXmlTextPropertyName) {
+        return new JacksonXmlAnnotationIntrospectorConfig(inferXmlTextPropertyName, this.xmlTextPropertyName);
+    }
+
+    public JacksonXmlAnnotationIntrospectorConfig withXmlTextPropertyName(PropertyName xmlTextPropertyName) {
+        return new JacksonXmlAnnotationIntrospectorConfig(this.inferXmlTextPropertyName, xmlTextPropertyName);
+    }
+}

--- a/src/main/java/tools/jackson/dataformat/xml/XmlMapper.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlMapper.java
@@ -67,7 +67,7 @@ public class XmlMapper extends ObjectMapper
             //    String into `null` (where it otherwise is an error) is very useful.
             enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
             _defaultUseWrapper = JacksonXmlAnnotationIntrospector.DEFAULT_USE_WRAPPER;
-            _nameForTextElement = FromXmlParser.DEFAULT_UNNAMED_TEXT_PROPERTY;
+            _nameForTextElement = FromXmlParser.DEFAULT_TEXT_PROPERTY;
 
             // as well as AnnotationIntrospector: note, however, that "use wrapper" may well
             // change later on

--- a/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -36,7 +36,7 @@ public class FromXmlParser
 {
     /**
      * The default name placeholder for XML text segments is &lt;xml:text&gt;
-     * @since 3.0.0 Is now &lt;xml:text&gt; - was empty String ("") before.
+     * @since 3.0 Is now &lt;xml:text&gt; - was empty String ("") before.
      */
     public final static String DEFAULT_TEXT_PROPERTY = "<xml:text>";
 

--- a/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -35,8 +35,12 @@ public class FromXmlParser
     implements ElementWrappable
 {
     /**
-     * The default name placeholder for XML text segments is &lt;xml:text&gt;
-     * @since 3.0 Is now &lt;xml:text&gt; - was empty String ("") before.
+     * The default name placeholder for XML text segments: used because Token stream
+     * requires all values inside "Objects" to have names associated.
+     * For Jackson 3.x this is {@code <xml:text>}; in 2.x matching constant was defined
+     * as empty String ({@code ""}).
+     * 
+     * @since 3.0 Constant was renamed: was {@code DEFAULT_UNNAMED_TEXT_PROPERTY} in 2.x
      */
     public final static String DEFAULT_TEXT_PROPERTY = "<xml:text>";
 

--- a/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -35,10 +35,10 @@ public class FromXmlParser
     implements ElementWrappable
 {
     /**
-     * The default name placeholder for XML text segments is empty
-     * String ("").
+     * The default name placeholder for XML text segments is &lt;xml:text&gt;
+     * @since 3.0.0 Is now &lt;xml:text&gt; - was empty String ("") before.
      */
-    public final static String DEFAULT_UNNAMED_TEXT_PROPERTY = "";
+    public final static String DEFAULT_TEXT_PROPERTY = "<xml:text>";
 
     /**
      * XML format has some peculiarities, indicated via capability
@@ -61,7 +61,7 @@ public class FromXmlParser
      * may be changed for inter-operability reasons: JAXB, for example, uses
      * "value" as name.
      */
-    protected String _cfgNameForTextElement = DEFAULT_UNNAMED_TEXT_PROPERTY;
+    protected String _cfgNameForTextElement = DEFAULT_TEXT_PROPERTY;
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlDeserializationContext.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlDeserializationContext.java
@@ -68,7 +68,7 @@ public class XmlDeserializationContext
             final String propName = p.currentName();
             JsonToken t = p.nextToken();
             if (t == JsonToken.VALUE_STRING) {
-                if (propName.equals("")) {
+                if (FromXmlParser.DEFAULT_TEXT_PROPERTY.equals(propName)) {
                     text = p.getString();
                 }
             } else {

--- a/src/test/java/tools/jackson/dataformat/xml/deser/DifferentDeserializationPropertyNameTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/DifferentDeserializationPropertyNameTest.java
@@ -1,0 +1,75 @@
+package tools.jackson.dataformat.xml.deser;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.PropertyName;
+import tools.jackson.dataformat.xml.JacksonXmlAnnotationIntrospector;
+import tools.jackson.dataformat.xml.JacksonXmlAnnotationIntrospectorConfig;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DifferentDeserializationPropertyNameTest extends XmlTestUtil {
+
+    static class TestBean {
+
+        @JacksonXmlProperty(localName = "wrong")
+        String wrong;
+
+        @JacksonXmlText
+        String name;
+
+
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods
+    /**********************************************************************
+     */
+
+    @Test
+    public void testWithExplicitProperty() {
+        final XmlMapper mapper = XmlMapper.builder()
+                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false, new JacksonXmlAnnotationIntrospectorConfig(false, new PropertyName("name"))))
+                .build();
+
+        String xmlInput = "<testBean>ABC123</testBean>";
+
+        TestBean testBean = mapper.readValue(xmlInput, TestBean.class);
+
+        assertEquals("ABC123", testBean.name);
+    }
+
+    @Test
+    public void testWithInferName() {
+        final XmlMapper mapper = XmlMapper.builder()
+                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false, new JacksonXmlAnnotationIntrospectorConfig(true, null)))
+                .build();
+
+        String xmlInput = "<testBean>DEF</testBean>";
+
+        TestBean testBean = mapper.readValue(xmlInput, TestBean.class);
+
+        assertEquals("DEF", testBean.name);
+    }
+
+    @Test
+    public void testWithDuplicateExplicitProperty() {
+        final XmlMapper mapper = XmlMapper.builder()
+                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false, new JacksonXmlAnnotationIntrospectorConfig(false, new PropertyName("wrong"))))
+                .build();
+
+        String xmlInput = "<testBean>DEF</testBean>";
+
+        Exception result = assertThrows(DatabindException.class, () -> mapper.readValue(xmlInput, TestBean.class));
+
+        assertTrue(result.getMessage().contains("Multiple fields representing property \"wrong\""));
+    }
+
+}

--- a/src/test/java/tools/jackson/dataformat/xml/deser/DifferentDeserializationPropertyNameTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/DifferentDeserializationPropertyNameTest.java
@@ -14,17 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DifferentDeserializationPropertyNameTest extends XmlTestUtil {
-
+public class DifferentDeserializationPropertyNameTest extends XmlTestUtil
+{
     static class TestBean {
-
         @JacksonXmlProperty(localName = "wrong")
         String wrong;
 
         @JacksonXmlText
         String name;
-
-
     }
 
     /*
@@ -36,7 +33,8 @@ public class DifferentDeserializationPropertyNameTest extends XmlTestUtil {
     @Test
     public void testWithExplicitProperty() {
         final XmlMapper mapper = XmlMapper.builder()
-                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false, new JacksonXmlAnnotationIntrospectorConfig(false, new PropertyName("name"))))
+                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false,
+                        new JacksonXmlAnnotationIntrospectorConfig(false, new PropertyName("name"))))
                 .build();
 
         String xmlInput = "<testBean>ABC123</testBean>";
@@ -49,7 +47,8 @@ public class DifferentDeserializationPropertyNameTest extends XmlTestUtil {
     @Test
     public void testWithInferName() {
         final XmlMapper mapper = XmlMapper.builder()
-                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false, new JacksonXmlAnnotationIntrospectorConfig(true, null)))
+                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false,
+                        new JacksonXmlAnnotationIntrospectorConfig(true, null)))
                 .build();
 
         String xmlInput = "<testBean>DEF</testBean>";
@@ -62,7 +61,8 @@ public class DifferentDeserializationPropertyNameTest extends XmlTestUtil {
     @Test
     public void testWithDuplicateExplicitProperty() {
         final XmlMapper mapper = XmlMapper.builder()
-                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false, new JacksonXmlAnnotationIntrospectorConfig(false, new PropertyName("wrong"))))
+                .annotationIntrospector(new JacksonXmlAnnotationIntrospector(false,
+                        new JacksonXmlAnnotationIntrospectorConfig(false, new PropertyName("wrong"))))
                 .build();
 
         String xmlInput = "<testBean>DEF</testBean>";
@@ -71,5 +71,4 @@ public class DifferentDeserializationPropertyNameTest extends XmlTestUtil {
 
         assertTrue(result.getMessage().contains("Multiple fields representing property \"wrong\""));
     }
-
 }

--- a/src/test/java/tools/jackson/dataformat/xml/deser/MapDeserializationTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/MapDeserializationTest.java
@@ -41,7 +41,7 @@ public class MapDeserializationTest extends XmlTestUtil
          assertEquals(1, map.size());
          Map<String,Object> inner = new LinkedHashMap<>();
          inner.put("lang", "en");
-         inner.put("", "John Smith");
+         inner.put(FromXmlParser.DEFAULT_TEXT_PROPERTY, "John Smith");
          assertEquals(Collections.singletonMap("person", inner), map);
     }
 }

--- a/src/test/java/tools/jackson/dataformat/xml/deser/UntypedObjectDeserTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/UntypedObjectDeserTest.java
@@ -77,7 +77,7 @@ public class UntypedObjectDeserTest extends XmlTestUtil
         final String XML = "<root>first<a>123</a>second<b>abc</b>last</root>";
         final JsonNode fromXml = XML_MAPPER.valueToTree(XML_MAPPER.readValue(XML, Object.class));
         final ObjectNode exp = XML_MAPPER.createObjectNode();
-        exp.putArray("")
+        exp.putArray(FromXmlParser.DEFAULT_TEXT_PROPERTY)
             .add("first")
             .add("second")
             .add("last");

--- a/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeBasicDeserTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeBasicDeserTest.java
@@ -7,6 +7,7 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.JsonNodeType;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.deser.FromXmlParser;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -43,7 +44,7 @@ public class JsonNodeBasicDeserTest extends XmlTestUtil
     {
         JsonNode fromXml = XML_MAPPER.readTree("<root>first<a>123</a>second<b>abc</b>last</root>");
         final ObjectNode exp = XML_MAPPER.createObjectNode();
-        exp.putArray("")
+        exp.putArray(FromXmlParser.DEFAULT_TEXT_PROPERTY)
             .add("first")
             .add("second")
             .add("last");

--- a/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeMixedContent403Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeMixedContent403Test.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.deser.FromXmlParser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -19,7 +20,7 @@ public class JsonNodeMixedContent403Test extends XmlTestUtil
     public void testMixedContentBefore() throws Exception
     {
         // First, before elements:
-        assertEquals(JSON_MAPPER.readTree(a2q("{'':'before','a':'1','b':'2'}")),
+        assertEquals(JSON_MAPPER.readTree(a2q(String.format("{'%s':'before','a':'1','b':'2'}", FromXmlParser.DEFAULT_TEXT_PROPERTY))),
                 XML_MAPPER.readTree("<root>before<a>1</a><b>2</b></root>"));
     }
 
@@ -27,7 +28,7 @@ public class JsonNodeMixedContent403Test extends XmlTestUtil
     public void testMixedContentBetween() throws Exception
     {
         // Second, between
-        assertEquals(JSON_MAPPER.readTree(a2q("{'a':'1','':'between','b':'2'}")),
+        assertEquals(JSON_MAPPER.readTree(a2q(String.format("{'a':'1','%s':'between','b':'2'}", FromXmlParser.DEFAULT_TEXT_PROPERTY))),
                 XML_MAPPER.readTree("<root><a>1</a>between<b>2</b></root>"));
     }
 
@@ -35,7 +36,7 @@ public class JsonNodeMixedContent403Test extends XmlTestUtil
     public void testMixedContentAfter() throws Exception
     {
         // and then after
-        assertEquals(JSON_MAPPER.readTree(a2q("{'a':'1','b':'2','':'after'}")),
+        assertEquals(JSON_MAPPER.readTree(a2q(String.format("{'a':'1','b':'2','%s':'after'}", FromXmlParser.DEFAULT_TEXT_PROPERTY))),
                 XML_MAPPER.readTree("<root><a>1</a><b>2</b>after</root>"));
     }
 
@@ -44,7 +45,7 @@ public class JsonNodeMixedContent403Test extends XmlTestUtil
     {
         // and then after
         assertEquals(JSON_MAPPER.readTree(
-                a2q("{'':['first','second','third'],'a':'1','b':'2'}")),
+                a2q(String.format("{'%s':['first','second','third'],'a':'1','b':'2'}", FromXmlParser.DEFAULT_TEXT_PROPERTY))),
                 XML_MAPPER.readTree("<root>first<a>1</a>second<b>2</b>third</root>"));
     }
 
@@ -57,7 +58,7 @@ public class JsonNodeMixedContent403Test extends XmlTestUtil
                 +" mixed2</a>\n"
                 +"</root>";
         JsonNode fromJson = JSON_MAPPER.readTree(
-                a2q("{'a':{'':['mixed1 ',' mixed2'],'b':'leaf'}}"));
+                a2q(String.format("{'a':{'%s':['mixed1 ',' mixed2'],'b':'leaf'}}", FromXmlParser.DEFAULT_TEXT_PROPERTY)));
         assertEquals(fromJson, XML_MAPPER.readTree(XML));
     }
 }

--- a/src/test/java/tools/jackson/dataformat/xml/stream/XmlParser442Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/stream/XmlParser442Test.java
@@ -44,7 +44,7 @@ public class XmlParser442Test extends XmlTestUtil
             // Here's what we are missing:
             assertToken(JsonToken.START_OBJECT, xp.nextToken());
             assertToken(JsonToken.PROPERTY_NAME, xp.nextToken());
-            assertEquals("", xp.currentName());
+            assertEquals(FromXmlParser.DEFAULT_TEXT_PROPERTY, xp.currentName());
 
             assertToken(JsonToken.VALUE_STRING, xp.nextToken());
             assertEquals("text", xp.getString().trim());

--- a/src/test/java/tools/jackson/dataformat/xml/stream/XmlParserTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/stream/XmlParserTest.java
@@ -99,7 +99,7 @@ public class XmlParserTest extends XmlTestUtil
         try (JsonParser p = _xmlMapper.createParser(XML)) {
             assertToken(JsonToken.START_OBJECT, p.nextToken());
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-            assertEquals("", p.currentName());
+            assertEquals(FromXmlParser.DEFAULT_TEXT_PROPERTY, p.currentName());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
             assertEquals("value", p.getString());
             assertToken(JsonToken.END_OBJECT, p.nextToken());
@@ -118,7 +118,7 @@ public class XmlParserTest extends XmlTestUtil
             assertToken(JsonToken.START_OBJECT, p.nextToken());
 
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-            assertEquals("", p.currentName());
+            assertEquals(FromXmlParser.DEFAULT_TEXT_PROPERTY, p.currentName());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
             assertEquals("value", p.getString());
 
@@ -343,7 +343,7 @@ public class XmlParserTest extends XmlTestUtil
     @Test
     public void testMixedContent() throws Exception
     {
-        String exp = a2q("{'':'first','a':'123','':'second','b':'456','':'last'}");
+        String exp = a2q(String.format("{'%1$s':'first','a':'123','%1$s':'second','b':'456','%1$s':'last'}", FromXmlParser.DEFAULT_TEXT_PROPERTY));
         String result = _readXmlWriteJson("<root>first<a>123</a>second<b>456</b>last</root>");
 
 //System.err.println("result = \n"+result);
@@ -373,7 +373,7 @@ public class XmlParserTest extends XmlTestUtil
         assertEquals(42, xp.getIntValue());
 
         assertToken(JsonToken.PROPERTY_NAME, xp.nextToken()); // implicit for text
-        assertEquals("", xp.currentName());
+        assertEquals(FromXmlParser.DEFAULT_TEXT_PROPERTY, xp.currentName());
 
         assertToken(JsonToken.VALUE_STRING, xp.nextToken());
         assertTrue(xp.isExpectedNumberIntToken());

--- a/src/test/java/tools/jackson/dataformat/xml/tofix/XmlTextViaCreator306Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/tofix/XmlTextViaCreator306Test.java
@@ -116,7 +116,6 @@ public class XmlTextViaCreator306Test extends XmlTestUtil
     }
 
     // [dataformat-xml#423]
-    @JacksonTestFailureExpected
     @Test
     public void testXmlTextViaCtor423() throws Exception
     {

--- a/src/test/java/tools/jackson/dataformat/xml/tofix/records/XmlRecordDeser734Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/tofix/records/XmlRecordDeser734Test.java
@@ -18,7 +18,6 @@ public class XmlRecordDeser734Test extends XmlTestUtil
     private final String XML =
             a2q("<Amt Ccy='EUR'>1</Amt>");
 
-    @JacksonTestFailureExpected
     @Test
     public void testDeser() throws Exception {
         XmlMapper mapper = new XmlMapper();


### PR DESCRIPTION
This PR aims to fix #306 naively by just changing the default property name of XmlText from `""` to `<xml:text>`. The new value was chosen, because it is an invalid property and element name in XML and thus should hopefully not collide with existing setups.

I was not sure if XmlText having the property name `""` is considered an implementation detail. If it is not an implementation detail this is most likely to be considered as a breaking change.

Feel free to close this PR if e.g. something else is planned to fix #306 or if XmlText has to keep the property name empty string because of compatibility reasons.