### PR TITLE
[issue 768]FromXmlParser lacks extension point for custom XmlTokenStream

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -276,3 +276,8 @@ Bas Passon (@bpasson)
 
 * Contributed #745: Add feature to include `standalone='yes'` in xml declaration
  (2.19.0)
+
+(@xzxiaoshan)
+* Contributed #768: `FromXmlParser` lacks extension point for passing
+  custom `XmlTokenStream`
+ (2.20.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,6 +6,8 @@ Project: jackson-dataformat-xml
 
 2.20.0 (not yet released)
 
+#768: `FromXmlParser` lacks extension point for passing custom `XmlTokenStream`
+ (contributed by @xzxiaoshan)
 - Generate SBOMs [JSTEP-14]
 
 2.19.1 (13-Jun-2025)

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
@@ -559,12 +559,23 @@ public class XmlFactory extends JsonFactory
         }
 
         // false -> not managed
-        FromXmlParser xp = new FromXmlParser(_createContext(_createContentReference(sr), false),
+        FromXmlParser xp = this.createParser(_createContext(_createContentReference(sr), false),
                 _parserFeatures, _xmlParserFeatures, _objectCodec, sr, _nameProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
         }
         return xp;
+    }
+
+    /**
+     * Creates and returns a new instance of {@link FromXmlParser} configured with the provided parameters.
+     * If you need to extend or customize the FromXmlParser, you can simply override this method.
+     *
+     * @since 2.20
+     */
+    protected FromXmlParser createParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures, ObjectCodec codec,
+                                         XMLStreamReader xmlReader, XmlNameProcessor tagProcessor) throws IOException {
+        return new FromXmlParser(ctxt, genericParserFeatures, xmlFeatures, codec, xmlReader, tagProcessor);
     }
 
     /**
@@ -598,7 +609,7 @@ public class XmlFactory extends JsonFactory
             return StaxUtil.throwAsParseException(e, null);
         }
         sr = _initializeXmlReader(sr);
-        FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
+        FromXmlParser xp = this.createParser(ctxt, _parserFeatures, _xmlParserFeatures,
                 _objectCodec, sr, _nameProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
@@ -616,7 +627,7 @@ public class XmlFactory extends JsonFactory
             return StaxUtil.throwAsParseException(e, null);
         }
         sr = _initializeXmlReader(sr);
-        FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
+        FromXmlParser xp = this.createParser(ctxt, _parserFeatures, _xmlParserFeatures,
                 _objectCodec, sr, _nameProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
@@ -643,7 +654,7 @@ public class XmlFactory extends JsonFactory
             return StaxUtil.throwAsParseException(e, null);
         }
         sr = _initializeXmlReader(sr);
-        FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
+        FromXmlParser xp = this.createParser(ctxt, _parserFeatures, _xmlParserFeatures,
                 _objectCodec, sr, _nameProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);
@@ -677,7 +688,7 @@ public class XmlFactory extends JsonFactory
             return StaxUtil.throwAsParseException(e, null);
         }
         sr = _initializeXmlReader(sr);
-        FromXmlParser xp = new FromXmlParser(ctxt, _parserFeatures, _xmlParserFeatures,
+        FromXmlParser xp = this.createParser(ctxt, _parserFeatures, _xmlParserFeatures,
                 _objectCodec, sr, _nameProcessor);
         if (_cfgNameForTextElement != null) {
             xp.setXMLTextElementName(_cfgNameForTextElement);

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
@@ -502,6 +502,16 @@ public class XmlFactory extends JsonFactory
     /**********************************************************
      */
 
+    /**
+     * Overriding this method makes it easy to extend and customize the ToXmlGenerator.
+     *
+     * @since 2.20
+     */
+    public ToXmlGenerator createGenerator(IOContext ctxt, int stdFeatures, int xmlFeatures, ObjectCodec codec,
+                                          XMLStreamWriter sw, XmlNameProcessor nameProcessor) {
+        return new ToXmlGenerator(ctxt, stdFeatures, xmlFeatures, codec, sw, nameProcessor);
+    }
+
     @Override
     public ToXmlGenerator createGenerator(OutputStream out) throws IOException {
         return createGenerator(out, JsonEncoding.UTF8);
@@ -513,7 +523,7 @@ public class XmlFactory extends JsonFactory
         // false -> we won't manage the stream unless explicitly directed to
         final IOContext ctxt = _createContext(_createContentReference(out), false);
         ctxt.setEncoding(enc);
-        return new ToXmlGenerator(ctxt,
+        return this.createGenerator(ctxt,
                 _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, _createXmlWriter(ctxt, out), _nameProcessor);
     }
@@ -522,7 +532,7 @@ public class XmlFactory extends JsonFactory
     public ToXmlGenerator createGenerator(Writer out) throws IOException
     {
         final IOContext ctxt = _createContext(_createContentReference(out), false);
-        return new ToXmlGenerator(ctxt,
+        return this.createGenerator(ctxt,
                 _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, _createXmlWriter(ctxt, out), _nameProcessor);
     }
@@ -535,7 +545,7 @@ public class XmlFactory extends JsonFactory
         // true -> yes, we have to manage the stream since we created it
         final IOContext ctxt = _createContext(_createContentReference(out), true);
         ctxt.setEncoding(enc);
-        return new ToXmlGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
+        return this.createGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, _createXmlWriter(ctxt, out), _nameProcessor);
     }
 
@@ -589,7 +599,7 @@ public class XmlFactory extends JsonFactory
     {
         sw = _initializeXmlWriter(sw);
         IOContext ctxt = _createContext(_createContentReference(sw), false);
-        return new ToXmlGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
+        return this.createGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, sw, _nameProcessor);
     }
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java
@@ -38,16 +38,16 @@ public class XmlFactory extends JsonFactory
     public final static String FORMAT_NAME_XML = "XML";
 
     /**
-     * Bitfield (set of flags) of all parser features that are enabled
+     * Bit field (set of flags) of all parser features that are enabled
      * by default.
      */
-    final static int DEFAULT_XML_PARSER_FEATURE_FLAGS = FromXmlParser.Feature.collectDefaults();
+    protected final static int DEFAULT_XML_PARSER_FEATURE_FLAGS = FromXmlParser.Feature.collectDefaults();
 
     /**
-     * Bitfield (set of flags) of all generator features that are enabled
+     * Bit field (set of flags) of all generator features that are enabled
      * by default.
      */
-    final static int DEFAULT_XML_GENERATOR_FEATURE_FLAGS = ToXmlGenerator.Feature.collectDefaults();
+    protected final static int DEFAULT_XML_GENERATOR_FEATURE_FLAGS = ToXmlGenerator.Feature.collectDefaults();
 
     /*
     /**********************************************************
@@ -502,16 +502,6 @@ public class XmlFactory extends JsonFactory
     /**********************************************************
      */
 
-    /**
-     * Overriding this method makes it easy to extend and customize the ToXmlGenerator.
-     *
-     * @since 2.20
-     */
-    public ToXmlGenerator createGenerator(IOContext ctxt, int stdFeatures, int xmlFeatures, ObjectCodec codec,
-                                          XMLStreamWriter sw, XmlNameProcessor nameProcessor) {
-        return new ToXmlGenerator(ctxt, stdFeatures, xmlFeatures, codec, sw, nameProcessor);
-    }
-
     @Override
     public ToXmlGenerator createGenerator(OutputStream out) throws IOException {
         return createGenerator(out, JsonEncoding.UTF8);
@@ -523,7 +513,7 @@ public class XmlFactory extends JsonFactory
         // false -> we won't manage the stream unless explicitly directed to
         final IOContext ctxt = _createContext(_createContentReference(out), false);
         ctxt.setEncoding(enc);
-        return this.createGenerator(ctxt,
+        return createGenerator(ctxt,
                 _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, _createXmlWriter(ctxt, out), _nameProcessor);
     }
@@ -532,7 +522,7 @@ public class XmlFactory extends JsonFactory
     public ToXmlGenerator createGenerator(Writer out) throws IOException
     {
         final IOContext ctxt = _createContext(_createContentReference(out), false);
-        return this.createGenerator(ctxt,
+        return createGenerator(ctxt,
                 _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, _createXmlWriter(ctxt, out), _nameProcessor);
     }
@@ -545,7 +535,7 @@ public class XmlFactory extends JsonFactory
         // true -> yes, we have to manage the stream since we created it
         final IOContext ctxt = _createContext(_createContentReference(out), true);
         ctxt.setEncoding(enc);
-        return this.createGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
+        return createGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, _createXmlWriter(ctxt, out), _nameProcessor);
     }
 
@@ -584,7 +574,7 @@ public class XmlFactory extends JsonFactory
      * @since 2.20
      */
     protected FromXmlParser createParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures, ObjectCodec codec,
-                                         XMLStreamReader xmlReader, XmlNameProcessor tagProcessor) throws IOException {
+            XMLStreamReader xmlReader, XmlNameProcessor tagProcessor) throws IOException {
         return new FromXmlParser(ctxt, genericParserFeatures, xmlFeatures, codec, xmlReader, tagProcessor);
     }
 
@@ -599,8 +589,19 @@ public class XmlFactory extends JsonFactory
     {
         sw = _initializeXmlWriter(sw);
         IOContext ctxt = _createContext(_createContentReference(sw), false);
-        return this.createGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
+        return createGenerator(ctxt, _generatorFeatures, _xmlGeneratorFeatures,
                 _objectCodec, sw, _nameProcessor);
+    }
+
+    /**
+     * Factory method called by more other {@code creatoGenerator} methods.
+     * Overriding this method makes it easy to extend and customize the ToXmlGenerator.
+     *
+     * @since 2.20
+     */
+    public ToXmlGenerator createGenerator(IOContext ctxt, int stdFeatures, int xmlFeatures, ObjectCodec codec,
+            XMLStreamWriter sw, XmlNameProcessor nameProcessor) {
+        return new ToXmlGenerator(ctxt, stdFeatures, xmlFeatures, codec, sw, nameProcessor);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -274,17 +274,20 @@ public class FromXmlParser
      */
 
     public FromXmlParser(IOContext ctxt, int genericParserFeatures, int xmlFeatures,
-             ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor)
-        throws IOException
-    {
+             ObjectCodec codec, XMLStreamReader xmlReader, XmlNameProcessor tagProcessor) throws IOException {
+        this(ctxt, genericParserFeatures, codec, new XmlTokenStream(xmlReader, ctxt.contentReference(), xmlFeatures, tagProcessor));
+    }
+
+    public FromXmlParser(IOContext ctxt, int genericParserFeatures, ObjectCodec codec, XmlTokenStream xmlTokenStream) throws IOException {
         super(genericParserFeatures, ctxt.streamReadConstraints());
-        _formatFeatures = xmlFeatures;
         _ioContext = ctxt;
         _objectCodec = codec;
         _parsingContext = XmlReadContext.createRootContext(-1, -1);
-        _xmlTokens = new XmlTokenStream(xmlReader, ctxt.contentReference(),
-                    _formatFeatures, tagProcessor);
-
+        if (xmlTokenStream == null) {
+            throw new IllegalArgumentException("xmlTokenStream cannot be null");
+        }
+        _xmlTokens = xmlTokenStream;
+        _formatFeatures = xmlTokenStream.getFormatFeatures();
         final int firstToken;
         try {
             firstToken = _xmlTokens.initialize();

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -5,6 +5,7 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.xml.XMLConstants;
@@ -278,15 +279,24 @@ public class FromXmlParser
         this(ctxt, genericParserFeatures, codec, new XmlTokenStream(xmlReader, ctxt.contentReference(), xmlFeatures, tagProcessor));
     }
 
+    /**
+     * Constructs a new {@link FromXmlParser} instance using the provided XML token stream.
+     * This constructor initializes the parser with the given I/O context, parser features,
+     * and object codec for deserializing XML content into Java objects.
+     *
+     * @since 2.20
+     * @param ctxt I/O context used for handling low-level I/O operations and buffering
+     * @param genericParserFeatures set of bitmasked parser features to control parsing behavior
+     * @param codec object codec used for converting between JSON-like structures and Java objects
+     * @param xmlTokenStream the pre-processed XML token stream to parse from
+     * @throws IOException if an I/O error occurs during initialization or parsing setup
+     */
     public FromXmlParser(IOContext ctxt, int genericParserFeatures, ObjectCodec codec, XmlTokenStream xmlTokenStream) throws IOException {
         super(genericParserFeatures, ctxt.streamReadConstraints());
         _ioContext = ctxt;
         _objectCodec = codec;
         _parsingContext = XmlReadContext.createRootContext(-1, -1);
-        if (xmlTokenStream == null) {
-            throw new IllegalArgumentException("xmlTokenStream cannot be null");
-        }
-        _xmlTokens = xmlTokenStream;
+        _xmlTokens = Objects.requireNonNull(xmlTokenStream, "xmlTokenStream cannot be null");
         _formatFeatures = xmlTokenStream.getFormatFeatures();
         final int firstToken;
         try {

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -254,6 +254,10 @@ public class XmlTokenStream
         _cfgProcessXsiType = FromXmlParser.Feature.AUTO_DETECT_XSI_TYPE.enabledIn(f);
     }
 
+    public int getFormatFeatures() {
+        return _formatFeatures;
+    }
+
     /*
     /**********************************************************************
     /* Public API

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -254,6 +254,12 @@ public class XmlTokenStream
         _cfgProcessXsiType = FromXmlParser.Feature.AUTO_DETECT_XSI_TYPE.enabledIn(f);
     }
 
+    /**
+     * get FormatFeatures
+     *
+     * @return data
+     * @since 2.20
+     */
     public int getFormatFeatures() {
         return _formatFeatures;
     }


### PR DESCRIPTION
https://github.com/FasterXML/jackson-dataformat-xml/issues/768

This PR adds an extension point to FromXmlParser to allow customization of the XmlTokenStream implementation. No logic changes are made — it’s purely an additive change to support extensibility.

If this can be merged and released in a new version soon, it would be greatly appreciated as it's needed for our project.

Thank you!

---

1、By abstracting the createParser method, developers no longer need to override four _createParser methods in XmlFactory when implementing their own custom FromXmlParser.
2、Abstract a createGenerator method to make it easier to extend.

This change is purely structural and does not involve any modification to the underlying logic of the code.
