### PR TITLE
Fix #793: call _assignGenerator

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -10,3 +10,15 @@ Morten Olav Hansen (mortenoh@github)
 * Reported #25: `ACCEPT_EMPTY_STRING_AS_NULL_OBJECT` not honored in xml module
   for attributes
  (3.0.0)
+
+Ghenadii Batalski (@ghenadiibatalski)
+
+* Reported #793: `XmlSerializationContext`: NPE _writeCapabilities not set for
+  `SerializationContext`
+ (3.0.4)
+
+PJ Fanning (@pjfanning)
+
+* Fixed #793: `XmlSerializationContext`: NPE _writeCapabilities not set for
+  `SerializationContext`
+ (3.0.4)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -5,6 +5,13 @@ Version: 3.x (for earlier see VERSION-2.x)
 === Releases === 
 ------------------------------------------------------------------------
 
+3.0.4 (not yet released)
+
+#793: `XmlSerializationContext`: NPE _writeCapabilities not set for
+  `SerializationContext`
+ (reported by Ghenadii B)
+ (fix by @pjfanning)
+
 3.0.3 (28-Nov-2025)
 
 No changes since 3.0.2

--- a/src/main/java/tools/jackson/dataformat/xml/ser/XmlSerializationContext.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/XmlSerializationContext.java
@@ -49,7 +49,7 @@ public class XmlSerializationContext extends SerializationContextExt
     @Override
     public void serializeValue(JsonGenerator gen, Object value) throws JacksonException
     {
-        _generator = gen;
+        _assignGenerator(gen);
         if (value == null) {
             _serializeXmlNull(gen);
             return;
@@ -101,7 +101,7 @@ public class XmlSerializationContext extends SerializationContextExt
     public void serializeValue(JsonGenerator gen, Object value, JavaType rootType,
             ValueSerializer<Object> ser) throws JacksonException
     {
-        _generator = gen;
+        _assignGenerator(gen);
         if (value == null) {
             _serializeXmlNull(gen);
             return;
@@ -155,7 +155,7 @@ public class XmlSerializationContext extends SerializationContextExt
             ValueSerializer<Object> valueSer, TypeSerializer typeSer)
         throws JacksonException
     {
-        _generator = gen;
+        _assignGenerator(gen);
         if (value == null) {
             _serializeXmlNull(gen);
             return;

--- a/src/test/java/tools/jackson/dataformat/xml/ser/TestSerialization.java
+++ b/src/test/java/tools/jackson/dataformat/xml/ser/TestSerialization.java
@@ -2,6 +2,7 @@ package tools.jackson.dataformat.xml.ser;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -146,7 +147,7 @@ public class TestSerialization extends XmlTestUtil
         map.put("b", 2);
 
         String xml;
-        
+
         xml = _xmlMapper.writeValueAsString(new WrapperBean<Map<?,?>>(map));
         assertEquals("<WrapperBean><value>"
                 +"<a>1</a>"
@@ -269,5 +270,14 @@ public class TestSerialization extends XmlTestUtil
         Doubles deserialized = _xmlMapper.readValue(xml, Doubles.class);
         assertEquals(original.attr, deserialized.attr);
         assertEquals(original.elem, deserialized.elem);
+    }
+
+    @Test
+    public void uuidSerializability() throws Exception
+    {
+        String uuidStr = "6D416BE5-7EA9-4981-897C-32C57226205E".toLowerCase();
+        String xml = _xmlMapper.writeValueAsString(new WrapperBean<UUID>(
+                UUID.fromString(uuidStr))).trim();
+        assertEquals("<WrapperBean><value>"+uuidStr+"</value></WrapperBean>", xml);
     }
 }


### PR DESCRIPTION
Needed because jackson-databind sets up _writeCapabilities using _assignGenerator

See #793 