### PR TITLE
create test cases for issue 615

### DIFF
--- a/src/test/java/tools/jackson/dataformat/xml/deser/EntityClassList615Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/EntityClassList615Test.java
@@ -1,0 +1,61 @@
+package tools.jackson.dataformat.xml.deser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static tools.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT;
+import static tools.jackson.databind.cfg.DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+// [dataformat-xml#615]
+public class EntityClassList615Test {
+
+    static class EntityClass {
+        @JacksonXmlText
+        @JsonProperty("kto")
+        public String kto;
+
+        @JacksonXmlProperty(isAttribute = true, localName = "Hkto")
+        @JsonProperty("hkto")
+        public String hkto;
+    }
+
+    static class EntityClassList {
+
+        @JacksonXmlElementWrapper(localName = "entities")
+        @JsonProperty("entity")
+        public List<EntityClass> entityClassList;
+    }
+
+    @Test
+    void testXmlDeser() {
+        XmlMapper xmlMapper = XmlMapper.builder()
+                .defaultUseWrapper(false)
+                .disable(WRITE_DATES_AS_TIMESTAMPS)
+                .enable(ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                .build();
+
+        String xmlString =
+                """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <EntityclassList>
+                            <entities>
+                                <kto Hkto="6543210000">4561230000</kto>
+                                <kto Hkto="6543210000">5678910012</kto>
+                                <kto Hkto="">5678910013</kto>
+                                <kto Hkto="654321">567891</kto>
+                                <kto>5678910014</kto>
+                                <kto>567891</kto>
+                            </entities>
+                        </EntityclassList>""";
+
+        EntityClassList entityClassList = xmlMapper.readValue(xmlString, EntityClassList.class);
+        assertNotNull(entityClassList);
+    }
+}

--- a/src/test/java/tools/jackson/dataformat/xml/deser/EntityClassList615Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/EntityClassList615Test.java
@@ -1,13 +1,13 @@
 package tools.jackson.dataformat.xml.deser;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.junit.jupiter.api.Test;
 import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static tools.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT;

--- a/src/test/java/tools/jackson/dataformat/xml/tofix/records/EntityRecordList615Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/tofix/records/EntityRecordList615Test.java
@@ -1,5 +1,7 @@
 package tools.jackson.dataformat.xml.tofix.records;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.junit.jupiter.api.Test;
 import tools.jackson.dataformat.xml.XmlMapper;
@@ -7,8 +9,6 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
 import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static tools.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT;

--- a/src/test/java/tools/jackson/dataformat/xml/tofix/records/EntityRecordList615Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/tofix/records/EntityRecordList615Test.java
@@ -1,0 +1,60 @@
+package tools.jackson.dataformat.xml.tofix.records;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static tools.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT;
+import static tools.jackson.databind.cfg.DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+// [dataformat-xml#615]
+public class EntityRecordList615Test {
+
+    record EntityRecord(@JacksonXmlText
+                        @JsonProperty("kto")
+                        String kto,
+                        @JacksonXmlProperty(isAttribute = true, localName = "Hkto")
+                        @JsonProperty("hkto")
+                        String hkto) {
+    }
+
+    record EntityRecordList(@JacksonXmlElementWrapper(localName = "entities")
+                            @JsonProperty("entity")
+                            List<EntityRecord> entityRecordList) {
+    }
+
+    @Test
+    @JacksonTestFailureExpected
+    void testXmlDeser() {
+        XmlMapper xmlMapper = XmlMapper.builder()
+                .defaultUseWrapper(false)
+                .disable(WRITE_DATES_AS_TIMESTAMPS)
+                .enable(ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                .build();
+
+        String xmlString =
+                """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <EntityrecordList>
+                            <entities>
+                                <kto Hkto="6543210000">4561230000</kto>
+                                <kto Hkto="6543210000">5678910012</kto>
+                                <kto Hkto="">5678910013</kto>
+                                <kto Hkto="654321">567891</kto>
+                                <kto>5678910014</kto>
+                                <kto>567891</kto>
+                            </entities>
+                        </EntityrecordList>""";
+
+        EntityRecordList entityRecordList =
+                xmlMapper.readValue(xmlString, EntityRecordList.class);
+        assertNotNull(entityRecordList);
+    }
+}


### PR DESCRIPTION
based on tests in https://github.com/FasterXML/jackson-dataformat-xml/issues/615#issuecomment-3919119505 provided by @ghenadiibatalski

The record based test fails while the POJO equivalent passes.