### PR TITLE
Fix for #615: Use ValueInstantiators to rename creator properties so they match property definitions

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -22,3 +22,38 @@ PJ Fanning (@pjfanning)
 * Fixed #793: `XmlSerializationContext`: NPE _writeCapabilities not set for
   `SerializationContext`
  (3.0.4)
+
+Dai MIKURUBE (@dmikurube)
+
+* Reported #149: `@JacksonXmlElementWrapper` as a `@JsonCreator parameter` not working
+ (3.2.0)
+
+Christopher McVay (@mcvayc)
+
+* Fixed #149: `@JacksonXmlElementWrapper` as a `@JsonCreator parameter` not working
+ (3.2.0)
+* Fixed #517: XML wrapper doesn't work with java records
+ (3.2.0)
+* Fixed #615: Deserialization of Xml with `@JacksonXmlText` using `@JsonCreator` (into
+  `java.util.Map`) fails
+ (3.2.0)
+* Fixed #735: Java Record with `@JacksonXmlText` stopped working with 2.18
+ (3.2.0)
+* Fixed #795: `HttpHeader` object (= <httpHeaders>) is not wrapped by the XML `<property>` tag
+ (3.2.0)
+
+Josip Antoliš (@Antolius)
+
+* Reported #517: XML wrapper doesn't work with java records
+ (3.2.0)
+
+Severin Kistler (@kistlers)
+
+* Reported #615: Deserialization of Xml with `@JacksonXmlText` using `@JsonCreator` (into
+  `java.util.Map`) fails
+ (3.2.0)
+
+Charles Moulliard (@cmoulliard)
+
+* Reported #795: `HttpHeader` object (= <httpHeaders>) is not wrapped by the XML `<property>` tag
+ (3.2.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -9,6 +9,22 @@ Version: 3.x (for earlier see VERSION-2.x)
 
 #8: Serialization of `List` incorrect if property declared as plain `java.lang.Object`
  (fix by @cowtowncoder, w/ Claude code)
+#149: `@JacksonXmlElementWrapper` as a `@JsonCreator parameter` not working
+ (reported by Dai M)
+ (fix by Christopher M))
+#517: XML wrapper doesn't work with java records
+ (reported by Josip A)
+ (fix by Christopher M)
+#615: Deserialization of Xml with `@JacksonXmlText` using `@JsonCreator` (into
+  `java.util.Map`) fails
+ (reported by Severin K)
+ (fix by Christopher M)
+#735: Java Record with `@JacksonXmlText` stopped working with 2.18
+ (reported by @akastyka))
+ (fix by Christopher M)
+#795: `HttpHeader` object (= <httpHeaders>) is not wrapped by the XML `<property>` tag
+ (reported by Charles M)
+ (fix by Christopher M)
 #802: Serialization with Polymorphisme and `EXTERNAL_PROPERTY` = duplicate property
  (reported by @ Adrien-dev25 )
  (fix by @cowtowncoder, w/ Claude code)

--- a/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
@@ -30,6 +30,16 @@ public class JacksonXmlAnnotationIntrospector
     };
 
     /**
+     * Marker PropertyName used for {@code @JacksonXmlText} creator parameters.
+     * Must be non-empty so {@code PotentialCreator} recognizes the parameter as named.
+     * {@link tools.jackson.dataformat.xml.deser.XmlValueInstantiators} will later rename this to the actual text element
+     * name (empty string by default).
+     *
+     * @since 3.2
+     */
+    private final static PropertyName _XML_TEXT_NAME = PropertyName.construct("#xml.text");
+
+    /**
      * For backwards compatibility with 2.0, the default behavior is
      * to assume use of List wrapper if no annotations are used.
      */
@@ -209,6 +219,14 @@ public class JacksonXmlAnnotationIntrospector
                 super.findNameForDeserialization(config, a));
         if (pn == null) {
             if (_hasOneOf(a, ANNOTATIONS_TO_INFER_XML_PROP)) {
+                // [dataformat-xml#615]: Return non-empty name so PotentialCreator
+                // treats the parameter as named; XmlValueInstantiators renames to ""
+                if (a instanceof AnnotatedParameter) {
+                    JacksonXmlText textAnn = _findAnnotation(a, JacksonXmlText.class);
+                    if (textAnn != null && textAnn.value()) {
+                        return _XML_TEXT_NAME;
+                    }
+                }
                 return PropertyName.USE_DEFAULT;
             }
         }

--- a/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
@@ -37,7 +37,7 @@ public class JacksonXmlAnnotationIntrospector
      *
      * @since 3.2
      */
-    private final static PropertyName _XML_TEXT_NAME = PropertyName.construct("#xml.text");
+    private final static PropertyName _XML_TEXT_NAME = PropertyName.construct("&xml.text");
 
     /**
      * For backwards compatibility with 2.0, the default behavior is

--- a/src/main/java/tools/jackson/dataformat/xml/XmlModule.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlModule.java
@@ -4,6 +4,7 @@ import tools.jackson.core.Version;
 
 import tools.jackson.databind.JacksonModule;
 import tools.jackson.dataformat.xml.deser.XmlBeanDeserializerModifier;
+import tools.jackson.dataformat.xml.deser.XmlValueInstantiators;
 import tools.jackson.dataformat.xml.ser.XmlBeanSerializerModifier;
 
 public class XmlModule
@@ -34,5 +35,8 @@ public class XmlModule
         XmlMapper.Builder builder = (XmlMapper.Builder) context.getOwner();
         final String textElemName = builder.nameForTextElement();
         context.addDeserializerModifier(new XmlBeanDeserializerModifier(textElemName));
+        // [dataformat-xml#615]: XmlValueInstantiators renames creator properties
+        // to match the text element name used by updateProperties() and FromXmlParser
+        context.addValueInstantiators(new XmlValueInstantiators(textElemName));
     }
 }

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlTextDeserializer.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlTextDeserializer.java
@@ -90,10 +90,14 @@ public class XmlTextDeserializer
         throws JacksonException
     {
         if (p.currentToken() == JsonToken.VALUE_STRING) {
+            if (_valueInstantiator.canCreateUsingDefault()) {
                 Object bean = _valueInstantiator.createUsingDefault(ctxt);
                 _xmlTextProperty.deserializeAndSet(p, ctxt, bean);
                 return bean;
             }
+            // [dataformat-xml#615]: No default constructor (e.g. records);
+            // synthesize object tokens so the delegate can use property-based creators
+            return _deserializeFromStringViaDelegate(p, ctxt);
         }
         return _delegatee.deserialize(p,  ctxt);
     }
@@ -131,5 +135,24 @@ public class XmlTextDeserializer
                     +deser.getClass().getName());
         }
         return (BeanDeserializerBase) deser;
+    }
+
+    /**
+     * [dataformat-xml#615]: When the parser sees a bare VALUE_STRING but the type
+     * has no default constructor (e.g. Java records), wrap the text value as
+     * {@code { "": "text" }} so the delegate can use its property-based creator.
+     */
+    private Object _deserializeFromStringViaDelegate(JsonParser p,
+            DeserializationContext ctxt) throws JacksonException
+    {
+        TokenBuffer tb = ctxt.bufferForInputBuffering(p);
+        tb.writeStartObject();
+        tb.writeName(_xmlTextProperty.getName());
+        tb.writeString(p.getText());
+        tb.writeEndObject();
+        JsonParser syntheticParser = tb.asParserOnFirstToken(ctxt, p);
+        Object result = _delegatee.deserialize(syntheticParser, ctxt);
+        tb.close();
+        return result;
     }
 }

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlTextDeserializer.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlTextDeserializer.java
@@ -141,18 +141,21 @@ public class XmlTextDeserializer
      * [dataformat-xml#615]: When the parser sees a bare VALUE_STRING but the type
      * has no default constructor (e.g. Java records), wrap the text value as
      * {@code { "": "text" }} so the delegate can use its property-based creator.
+     *
+     * @since 3.2
      */
     private Object _deserializeFromStringViaDelegate(JsonParser p,
-            DeserializationContext ctxt) throws JacksonException
+            DeserializationContext ctxt)
+        throws JacksonException
     {
-        TokenBuffer tb = ctxt.bufferForInputBuffering(p);
-        tb.writeStartObject();
-        tb.writeName(_xmlTextProperty.getName());
-        tb.writeString(p.getText());
-        tb.writeEndObject();
-        JsonParser syntheticParser = tb.asParserOnFirstToken(ctxt, p);
-        Object result = _delegatee.deserialize(syntheticParser, ctxt);
-        tb.close();
-        return result;
+        try (TokenBuffer tb = ctxt.bufferForInputBuffering(p)) {
+            tb.writeStartObject();
+            tb.writeName(_xmlTextProperty.getName());
+            tb.writeString(p.getString());
+            tb.writeEndObject();
+            try (JsonParser syntheticParser = tb.asParserOnFirstToken(ctxt, p)) {
+                return _delegatee.deserialize(syntheticParser, ctxt);
+            }
+        }
     }
 }

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlTextDeserializer.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlTextDeserializer.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.deser.*;
 import tools.jackson.databind.deser.bean.BeanDeserializerBase;
 import tools.jackson.databind.deser.std.DelegatingDeserializer;
 import tools.jackson.databind.jsontype.TypeDeserializer;
+import tools.jackson.databind.util.TokenBuffer;
 
 /**
  * Delegating deserializer that is used in the special cases where
@@ -89,9 +90,10 @@ public class XmlTextDeserializer
         throws JacksonException
     {
         if (p.currentToken() == JsonToken.VALUE_STRING) {
-            Object bean = _valueInstantiator.createUsingDefault(ctxt);
-            _xmlTextProperty.deserializeAndSet(p, ctxt, bean);
-            return bean;
+                Object bean = _valueInstantiator.createUsingDefault(ctxt);
+                _xmlTextProperty.deserializeAndSet(p, ctxt, bean);
+                return bean;
+            }
         }
         return _delegatee.deserialize(p,  ctxt);
     }

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
@@ -1,0 +1,146 @@
+package tools.jackson.dataformat.xml.deser;
+
+import java.util.*;
+
+import tools.jackson.databind.*;
+import tools.jackson.databind.deser.SettableBeanProperty;
+import tools.jackson.databind.deser.ValueInstantiator;
+import tools.jackson.databind.deser.ValueInstantiators;
+import tools.jackson.databind.introspect.AnnotatedMember;
+import tools.jackson.databind.introspect.BeanPropertyDefinition;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+import tools.jackson.dataformat.xml.util.AnnotationUtil;
+
+/**
+ * {@link ValueInstantiators} implementation that renames creator properties
+ * to match the names that {@link XmlBeanDeserializerModifier#updateProperties}
+ * will give to the corresponding property definitions.
+ *<p>
+ * This is needed because {@code updateProperties()} renames property definitions
+ * (e.g., {@code @JacksonXmlText} properties to {@code ""}, wrapped collections to
+ * their wrapper name), but creator parameters retain their original names. Without
+ * this renaming, {@code BeanDeserializerFactory.addBeanProps()} cannot link property
+ * definitions to creator parameters.
+ *
+ * @since 3.2
+ */
+public class XmlValueInstantiators
+    extends ValueInstantiators.Base
+    implements java.io.Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    protected final String _cfgNameForTextValue;
+
+    public XmlValueInstantiators(String nameForTextValue)
+    {
+        _cfgNameForTextValue = nameForTextValue;
+    }
+
+    @Override
+    public ValueInstantiator modifyValueInstantiator(DeserializationConfig config,
+            BeanDescription.Supplier beanDescRef, ValueInstantiator defaultInstantiator)
+    {
+        SettableBeanProperty[] creatorProps = defaultInstantiator.getFromObjectArguments(config);
+        if (creatorProps == null || creatorProps.length == 0) {
+            return defaultInstantiator;
+        }
+
+        // Build a map of original-property-name -> new-name for renames that
+        // updateProperties() will perform on the property definitions.
+        // We need to apply the same renames to creator properties so names match.
+        Map<String, String> renames = _findPropertyRenames(config, beanDescRef);
+        if (renames.isEmpty()) {
+            // Also check for @JacksonXmlText directly on creator parameters
+            // (may not appear in bean property definitions for constructor-only classes)
+            if (!_hasXmlTextCreatorParam(creatorProps)) {
+                return defaultInstantiator;
+            }
+        }
+
+        for (int i = 0, len = creatorProps.length; i < len; ++i) {
+            SettableBeanProperty prop = creatorProps[i];
+            if (prop == null) {
+                continue;
+            }
+            final String propName = prop.getName();
+
+            // First check: direct @JacksonXmlText annotation on the creator parameter
+            JacksonXmlText textAnn = prop.getAnnotation(JacksonXmlText.class);
+            if (textAnn != null && textAnn.value()) {
+                if (!_cfgNameForTextValue.equals(propName)) {
+                    creatorProps[i] = prop.withSimpleName(_cfgNameForTextValue);
+                }
+                continue;
+            }
+
+            // Second check: rename map from property definitions
+            String newName = renames.get(propName);
+            if (newName != null && !newName.equals(propName)) {
+                creatorProps[i] = prop.withSimpleName(newName);
+            }
+        }
+        return defaultInstantiator;
+    }
+
+    private boolean _hasXmlTextCreatorParam(SettableBeanProperty[] creatorProps)
+    {
+        for (SettableBeanProperty prop : creatorProps) {
+            if (prop != null) {
+                JacksonXmlText textAnn = prop.getAnnotation(JacksonXmlText.class);
+                if (textAnn != null && textAnn.value()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Compute the property renames that {@code updateProperties()} will apply,
+     * by examining the bean's property definitions for {@code @JacksonXmlText}
+     * and wrapper name annotations.
+     *
+     * @return Map of original-property-name to new-property-name
+     */
+    private Map<String, String> _findPropertyRenames(DeserializationConfig config,
+            BeanDescription.Supplier beanDescRef)
+    {
+        final AnnotationIntrospector intr = config.getAnnotationIntrospector();
+        Map<String, String> renames = Collections.emptyMap();
+
+        for (BeanPropertyDefinition propDef : beanDescRef.get().findProperties()) {
+            AnnotatedMember member = propDef.getPrimaryMember();
+            if (member == null) {
+                continue;
+            }
+            final String origName = propDef.getName();
+
+            // Check @JacksonXmlText
+            Boolean isText = AnnotationUtil.findIsTextAnnotation(config, intr, member);
+            if (isText != null && isText.booleanValue()) {
+                if (!_cfgNameForTextValue.equals(origName)) {
+                    if (renames.isEmpty()) {
+                        renames = new HashMap<>();
+                    }
+                    renames.put(origName, _cfgNameForTextValue);
+                }
+                continue;
+            }
+
+            // Check wrapper name (for Lists)
+            PropertyName wrapperName = propDef.getWrapperName();
+            if (wrapperName != null && wrapperName != PropertyName.NO_NAME) {
+                String localName = wrapperName.getSimpleName();
+                if (localName != null && localName.length() > 0
+                        && !localName.equals(origName)) {
+                    if (renames.isEmpty()) {
+                        renames = new HashMap<>();
+                    }
+                    renames.put(origName, localName);
+                }
+            }
+        }
+        return renames;
+    }
+}

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
@@ -37,6 +37,22 @@ public class XmlValueInstantiators
         _cfgNameForTextValue = nameForTextValue;
     }
 
+    static class XmlDelegatingInstantiator extends ValueInstantiator.Delegating {
+        private static final long serialVersionUID = 1L;
+
+        private final SettableBeanProperty[] _renamedCreatorProps;
+
+        public XmlDelegatingInstantiator(ValueInstantiator delegate, SettableBeanProperty[] renamedCreatorProps) {
+            super(delegate);
+            this._renamedCreatorProps = renamedCreatorProps;
+        }
+
+        @Override
+        public SettableBeanProperty[] getFromObjectArguments(DeserializationConfig config) {
+            return _renamedCreatorProps;
+        }
+    }
+
     @Override
     public ValueInstantiator modifyValueInstantiator(DeserializationConfig config,
             BeanDescription.Supplier beanDescRef, ValueInstantiator defaultInstantiator)
@@ -45,6 +61,8 @@ public class XmlValueInstantiators
         if (creatorProps == null || creatorProps.length == 0) {
             return defaultInstantiator;
         }
+
+        SettableBeanProperty[] renamedCreatorProps = Arrays.copyOf(creatorProps, creatorProps.length);
 
         // Build a map of original-property-name -> new-name for renames that
         // updateProperties() will perform on the property definitions.
@@ -58,8 +76,9 @@ public class XmlValueInstantiators
             }
         }
 
-        for (int i = 0, len = creatorProps.length; i < len; ++i) {
-            SettableBeanProperty prop = creatorProps[i];
+        boolean hasRenames = false;
+        for (int i = 0, len = renamedCreatorProps.length; i < len; ++i) {
+            SettableBeanProperty prop = renamedCreatorProps[i];
             if (prop == null) {
                 continue;
             }
@@ -69,7 +88,8 @@ public class XmlValueInstantiators
             JacksonXmlText textAnn = prop.getAnnotation(JacksonXmlText.class);
             if (textAnn != null && textAnn.value()) {
                 if (!_cfgNameForTextValue.equals(propName)) {
-                    creatorProps[i] = prop.withSimpleName(_cfgNameForTextValue);
+                    renamedCreatorProps[i] = prop.withSimpleName(_cfgNameForTextValue);
+                    hasRenames = true;
                 }
                 continue;
             }
@@ -77,10 +97,14 @@ public class XmlValueInstantiators
             // Second check: rename map from property definitions
             String newName = renames.get(propName);
             if (newName != null && !newName.equals(propName)) {
-                creatorProps[i] = prop.withSimpleName(newName);
+                renamedCreatorProps[i] = prop.withSimpleName(newName);
+                hasRenames = true;
             }
         }
-        return defaultInstantiator;
+
+        return hasRenames ?
+                new XmlDelegatingInstantiator(defaultInstantiator, renamedCreatorProps)
+                : defaultInstantiator;
     }
 
     private boolean _hasXmlTextCreatorParam(SettableBeanProperty[] creatorProps)
@@ -110,8 +134,7 @@ public class XmlValueInstantiators
         Map<String, String> renames = Collections.emptyMap();
 
         for (BeanPropertyDefinition propDef : beanDescRef.get().findProperties()) {
-            AnnotatedMember member = propDef.getPrimaryMember();
-
+            final AnnotatedMember member = propDef.getPrimaryMember();
             final String origName = propDef.getName();
 
             // Check @JacksonXmlText

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
@@ -116,7 +116,7 @@ public class XmlValueInstantiators
 
             // Check @JacksonXmlText
             Boolean isText = AnnotationUtil.findIsTextAnnotation(config, intr, member);
-            if (isText != null && isText.booleanValue()) {
+            if (Boolean.TRUE.equals(isText)) {
                 if (!_cfgNameForTextValue.equals(origName)) {
                     if (renames.isEmpty()) {
                         renames = new HashMap<>();

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
@@ -111,9 +111,7 @@ public class XmlValueInstantiators
 
         for (BeanPropertyDefinition propDef : beanDescRef.get().findProperties()) {
             AnnotatedMember member = propDef.getPrimaryMember();
-            if (member == null) {
-                continue;
-            }
+
             final String origName = propDef.getName();
 
             // Check @JacksonXmlText

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
@@ -62,8 +62,6 @@ public class XmlValueInstantiators
             return defaultInstantiator;
         }
 
-        SettableBeanProperty[] renamedCreatorProps = Arrays.copyOf(creatorProps, creatorProps.length);
-
         // Build a map of original-property-name -> new-name for renames that
         // updateProperties() will perform on the property definitions.
         // We need to apply the same renames to creator properties so names match.
@@ -77,6 +75,7 @@ public class XmlValueInstantiators
         }
 
         boolean hasRenames = false;
+        SettableBeanProperty[] renamedCreatorProps = Arrays.copyOf(creatorProps, creatorProps.length);
         for (int i = 0, len = renamedCreatorProps.length; i < len; ++i) {
             SettableBeanProperty prop = renamedCreatorProps[i];
             if (prop == null) {
@@ -136,30 +135,30 @@ public class XmlValueInstantiators
         for (BeanPropertyDefinition propDef : beanDescRef.get().findProperties()) {
             final AnnotatedMember member = propDef.getPrimaryMember();
             final String origName = propDef.getName();
+            String renamed = null;
 
             // Check @JacksonXmlText
             Boolean isText = AnnotationUtil.findIsTextAnnotation(config, intr, member);
             if (Boolean.TRUE.equals(isText)) {
                 if (!_cfgNameForTextValue.equals(origName)) {
-                    if (renames.isEmpty()) {
-                        renames = new HashMap<>();
-                    }
-                    renames.put(origName, _cfgNameForTextValue);
+                    renamed = _cfgNameForTextValue;
                 }
-                continue;
+            } else {
+                // Check wrapper name (for Lists)
+                PropertyName wrapperName = propDef.getWrapperName();
+                if (wrapperName != null && wrapperName != PropertyName.NO_NAME) {
+                    String localName = wrapperName.getSimpleName();
+                    if (localName != null && localName.length() > 0
+                            && !localName.equals(origName)) {
+                        renamed = localName;
+                    }
+                }
             }
-
-            // Check wrapper name (for Lists)
-            PropertyName wrapperName = propDef.getWrapperName();
-            if (wrapperName != null && wrapperName != PropertyName.NO_NAME) {
-                String localName = wrapperName.getSimpleName();
-                if (localName != null && localName.length() > 0
-                        && !localName.equals(origName)) {
-                    if (renames.isEmpty()) {
-                        renames = new HashMap<>();
-                    }
-                    renames.put(origName, localName);
+            if (renamed != null) {
+                if (renames.isEmpty()) {
+                    renames = new HashMap<>();
                 }
+                renames.put(origName, renamed);
             }
         }
         return renames;

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -56,7 +56,6 @@ module tools.jackson.dataformat.xml
     opens tools.jackson.dataformat.xml.records;
     opens tools.jackson.dataformat.xml.stream;
     opens tools.jackson.dataformat.xml.tofix;
-    opens tools.jackson.dataformat.xml.tofix.records;
     opens tools.jackson.dataformat.xml.testutil.failure;
     opens tools.jackson.dataformat.xml.vld;
     opens tools.jackson.dataformat.xml.woodstox;

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -44,6 +44,7 @@ module tools.jackson.dataformat.xml
     opens tools.jackson.dataformat.xml.deser.builder;
     opens tools.jackson.dataformat.xml.deser.convert;
     opens tools.jackson.dataformat.xml.deser.creator;
+    opens tools.jackson.dataformat.xml.deser.records;
     opens tools.jackson.dataformat.xml.dos;
     opens tools.jackson.dataformat.xml.fuzz;
     opens tools.jackson.dataformat.xml.jaxb;

--- a/src/test/java/tools/jackson/dataformat/xml/deser/ElementWrapperViaCreator149Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/ElementWrapperViaCreator149Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.dataformat.xml.tofix;
+package tools.jackson.dataformat.xml.deser;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,14 +13,11 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-// 13-Nov-2020, tatu: Not quite sure how to configure test to pass;
-//   seems like it should work but does not. Leaving for future generations
-//   to figure out...
+// [dataformat-xml#149]
 public class ElementWrapperViaCreator149Test extends XmlTestUtil
 {
     @JsonRootName("body")
@@ -40,7 +37,7 @@ public class ElementWrapperViaCreator149Test extends XmlTestUtil
             this.type = type;
             this.labels = labels;
         }
-    }    
+    }
 
     /*
     /**********************************************************************
@@ -51,7 +48,6 @@ public class ElementWrapperViaCreator149Test extends XmlTestUtil
     private final ObjectMapper MAPPER = newMapper();
 
     // [dataformat-xml#149]
-    @JacksonTestFailureExpected
     @Test
     public void testElementWrapper149() throws Exception
     {
@@ -63,7 +59,5 @@ public class ElementWrapperViaCreator149Test extends XmlTestUtil
         assertEquals("TYPE", result.type);
         assertNotNull(result.labels);
         assertEquals(Arrays.asList("foo", "bar"), result.labels);
-
-//System.err.println("XML: "+MAPPER.writeValueAsString(result));        
     }
 }

--- a/src/test/java/tools/jackson/dataformat/xml/deser/ElementWrapperWithCreator795Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/ElementWrapperWithCreator795Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.dataformat.xml.tofix;
+package tools.jackson.dataformat.xml.deser;
 
 import java.util.List;
 
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -71,7 +70,6 @@ public class ElementWrapperWithCreator795Test extends XmlTestUtil
 
     // Deserialization fails: XmlBeanDeserializerModifier renames property to wrapper name
     // ("httpHeaders") but creator property retains original name ("property"), causing mismatch.
-    @JacksonTestFailureExpected
     @Test
     public void testDeserializeWithWrapper() throws Exception
     {

--- a/src/test/java/tools/jackson/dataformat/xml/deser/XmlTextViaCtor423Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/XmlTextViaCtor423Test.java
@@ -1,0 +1,42 @@
+package tools.jackson.dataformat.xml.deser;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// [dataformat-xml#423]
+public class XmlTextViaCtor423Test extends XmlTestUtil
+{
+    static class Sample423
+    {
+        final String text;
+        final String attribute;
+
+        @JsonCreator
+        public Sample423(@JacksonXmlText String text,
+                @JacksonXmlProperty(localName = "attribute", isAttribute = true)
+                String attribute) {
+            this.text = text;
+            this.attribute = attribute;
+        }
+    }
+
+    private final XmlMapper MAPPER = newMapper();
+
+    // [dataformat-xml#423]
+    @Test
+    public void testXmlTextViaCtor423() throws Exception
+    {
+        final String XML = "<Sample423 attribute='attrValue'>text value</Sample423>";
+        Sample423 result = MAPPER.readValue(XML, Sample423.class);
+        assertEquals("attrValue", result.attribute);
+        assertEquals("text value", result.text);
+    }
+}

--- a/src/test/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiatorsTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiatorsTest.java
@@ -1,0 +1,95 @@
+package tools.jackson.dataformat.xml.deser;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+// [dataformat-xml#615]: Additional coverage for XmlValueInstantiators
+public class XmlValueInstantiatorsTest extends XmlTestUtil
+{
+    static class FieldTextWithCreator {
+        @JacksonXmlText
+        String value;
+
+        @JacksonXmlProperty(isAttribute = true, localName = "attr")
+        String attr;
+
+        @JsonCreator
+        FieldTextWithCreator(@JsonProperty("value") String value,
+                             @JsonProperty("attr") String attr) {
+            this.value = value;
+            this.attr = attr;
+        }
+    }
+
+    record RecordTextAndAttribute(@JacksonXmlText String value,
+                  @JacksonXmlProperty(isAttribute = true, localName = "Ccy") String currency) {}
+
+    @JsonRootName("Mixed")
+    static class MixedTextAndWrapper {
+        final String text;
+        final List<String> items;
+
+        @JsonCreator
+        MixedTextAndWrapper(
+                @JacksonXmlText String text,
+                @JacksonXmlElementWrapper(localName = "items")
+                @JacksonXmlProperty(localName = "item")
+                List<String> items) {
+            this.text = text;
+            this.items = items;
+        }
+    }
+
+    private final XmlMapper MAPPER = newMapper();
+
+    @Test
+    public void testFieldTextWithCreator() throws Exception
+    {
+        final String XML = "<FieldTextWithCreator attr='hello'>world</FieldTextWithCreator>";
+        FieldTextWithCreator result = MAPPER.readValue(XML, FieldTextWithCreator.class);
+        assertEquals("world", result.value);
+        assertEquals("hello", result.attr);
+    }
+
+    @Test
+    public void testRecordRoundTrip() throws Exception
+    {
+        RecordTextAndAttribute original = new RecordTextAndAttribute("100", "USD");
+        String xml = MAPPER.writeValueAsString(original);
+        RecordTextAndAttribute result = MAPPER.readValue(xml, RecordTextAndAttribute.class);
+        assertEquals(original.value(), result.value());
+        assertEquals(original.currency(), result.currency());
+    }
+
+    @Test
+    public void testMixedTextAndWrapper() throws Exception
+    {
+        final String XML =
+                "<Mixed>" +
+                    "<items>" +
+                        "<item>a</item>" +
+                        "<item>b</item>" +
+                    "</items>" +
+                "</Mixed>";
+        MixedTextAndWrapper result = MAPPER.readValue(XML, MixedTextAndWrapper.class);
+        assertNotNull(result);
+        assertNotNull(result.items);
+        assertEquals(2, result.items.size());
+        assertEquals("a", result.items.get(0));
+        assertEquals("b", result.items.get(1));
+    }
+}

--- a/src/test/java/tools/jackson/dataformat/xml/deser/records/EntityRecordList615Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/records/EntityRecordList615Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.dataformat.xml.tofix.records;
+package tools.jackson.dataformat.xml.deser.records;
 
 import java.util.List;
 
@@ -8,7 +8,6 @@ import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
-import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static tools.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT;
@@ -31,7 +30,6 @@ public class EntityRecordList615Test {
     }
 
     @Test
-    @JacksonTestFailureExpected
     void testXmlDeser() {
         XmlMapper xmlMapper = XmlMapper.builder()
                 .defaultUseWrapper(false)

--- a/src/test/java/tools/jackson/dataformat/xml/deser/records/XmlRecordDeser735Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/records/XmlRecordDeser735Test.java
@@ -1,11 +1,10 @@
-package tools.jackson.dataformat.xml.tofix.records;
+package tools.jackson.dataformat.xml.deser.records;
 
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.dataformat.xml.*;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
-import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,12 +25,11 @@ public class XmlRecordDeser735Test extends XmlTestUtil
             this.currency = currency;
         }
     }
-    
+
     private final String XML = "<Amt Ccy='EUR'>1</Amt>";
 
     private final XmlMapper MAPPER = newMapper();
 
-    @JacksonTestFailureExpected
     @Test
     public void testPojoDeser() throws Exception {
         Pojo735 amt = MAPPER.readValue(XML, Pojo735.class);
@@ -39,7 +37,6 @@ public class XmlRecordDeser735Test extends XmlTestUtil
         assertEquals("EUR", amt.currency);
     }
 
-    @JacksonTestFailureExpected
     @Test
     public void testRecordDeser() throws Exception {
         Amount amt = MAPPER.readValue(XML, Amount.class);

--- a/src/test/java/tools/jackson/dataformat/xml/deser/records/XmlWrapperRecord517Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/records/XmlWrapperRecord517Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.dataformat.xml.tofix.records;
+package tools.jackson.dataformat.xml.deser.records;
 
 import java.util.List;
 
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -44,7 +43,6 @@ public class XmlWrapperRecord517Test
                     "</messages>" +
                 "</Request>";
 
-    @JacksonTestFailureExpected
     @Test
     public void testWrapper() throws Exception {
         XmlWrapperRecord517Test.Request request = new Request(List.of(new Message("Hello, World!")));

--- a/src/test/java/tools/jackson/dataformat/xml/tofix/XmlTextViaCreator306Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/tofix/XmlTextViaCreator306Test.java
@@ -12,7 +12,6 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
 import tools.jackson.dataformat.xml.testutil.failure.JacksonTestFailureExpected;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 // [dataformat-xml#306]: Problem is that `@XmlText` has the nominal property name
@@ -72,21 +71,6 @@ public class XmlTextViaCreator306Test extends XmlTestUtil
         public String el;
     }
 
-    // [dataformat-xml#423]
-    static class Sample423
-    {
-        final String text;
-        final String attribute;
-
-        @JsonCreator
-        public Sample423(@JacksonXmlText String text,
-                @JacksonXmlProperty(localName = "attribute", isAttribute = true)
-                String attribute) {
-            this.text = text;
-            this.attribute = attribute;
-        }
-    }
-
     /*
     /********************************************************
     /* Test methods
@@ -113,16 +97,5 @@ public class XmlTextViaCreator306Test extends XmlTestUtil
         final String XML = "<ROOT><CHILD attr='attr_value'>text</CHILD></ROOT>";
         RootWithoutConstructor rootNoCtor = MAPPER.readValue(XML, RootWithoutConstructor.class);
         assertNotNull(rootNoCtor);
-    }
-
-    // [dataformat-xml#423]
-    @JacksonTestFailureExpected
-    @Test
-    public void testXmlTextViaCtor423() throws Exception
-    {
-        final String XML = "<Sample423 attribute='attrValue'>text value</Sample423>";
-        Sample423 result = MAPPER.readValue(XML, Sample423.class);
-        assertEquals("attrValue", result.attribute);
-        assertEquals("text value", result.text);
     }
 }


### PR DESCRIPTION
Hi,

This PR was intended to fix #615 but in the process tests for #149, #517, #735, #795 in the `tofix` package started passing as well.  I've listed all the issues for which test are now passing in the commits, but still need to verify for those that the entire issue is fixed. 

The initial solution was co-written by Claude Code and me.  After collaboratively creating a fix, I subsequently read through the code and edited it for quality and consistency.  I believe the solution is now in decent shape, at least for #615.

Please let me know what you think.  I'm happy to make further edits.