### PR TITLE
Fix #334: @JacksonXmlElementWrapper(useWrapping=false) fails when using a DeserializerModifier that delegates

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -43,6 +43,10 @@ Eduard Wirch (@ewirch)
  * Reported #306: Can not use `@JacksonXmlText` for Creator property (creator parameter)
   (3.2.0)
 
+Ruven Chu (@Chubacca)
+ * Reported #334: `@JacksonXmlElementWrapper(useWrapping=false)` fails when using
+   a `DeserializerModifier` that delegates
+  
 Lon Varscsak (@lonvarscsak)
  * Reported #449: Trouble dealing with JacksonXMLText if properties are present or
    if element is in a collection

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,10 @@ Version: 3.x (for earlier see VERSION-2.x)
 #306: Can not use `@JacksonXmlText` for Creator property (creator parameter)
  (reported by Eduard W)
  (fix by Christopher M)
+#334: `@JacksonXmlElementWrapper(useWrapping=false)` fails when using
+  a `DeserializerModifier` that delegates
+ (reported by Ruven C)
+ (fix by @cowtowncoder, w/ Claude code)
 #426: `InvalidTypeIdException` when parsing XML to POJO containing nested `List<>`,
   custom `TypeIdResolver`
  (reported by @ankagar)

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
@@ -5,6 +5,7 @@ import java.util.*;
 import tools.jackson.databind.*;
 import tools.jackson.databind.deser.*;
 import tools.jackson.databind.deser.bean.BeanDeserializerBase;
+import tools.jackson.databind.deser.std.DelegatingDeserializer;
 import tools.jackson.databind.introspect.AnnotatedMember;
 import tools.jackson.databind.introspect.BeanPropertyDefinition;
 import tools.jackson.dataformat.xml.util.AnnotationUtil;
@@ -82,16 +83,31 @@ public class XmlBeanDeserializerModifier
     public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config,
             BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deser0)
     {
-        if (!(deser0 instanceof BeanDeserializerBase)) {
-            return deser0;
+        if (deser0 instanceof BeanDeserializerBase) {
+            return _modifyBeanDeserializer(config, (BeanDeserializerBase) deser0);
         }
+        // [dataformat-xml#334]: If a user's DeserializerModifier has wrapped the
+        //   BeanDeserializer in a DelegatingDeserializer, unwrap to find the
+        //   underlying BeanDeserializerBase, process it, and rebuild the chain.
+        if (deser0 instanceof DelegatingDeserializer) {
+            return _modifyThroughDelegation(config, (DelegatingDeserializer) deser0);
+        }
+        return deser0;
+    }
+
+    /**
+     * Core modification logic extracted so it can be applied both to direct
+     * {@link BeanDeserializerBase} instances and to ones found inside
+     * {@link DelegatingDeserializer} wrappers.
+     */
+    private ValueDeserializer<?> _modifyBeanDeserializer(DeserializationConfig config,
+            BeanDeserializerBase deser)
+    {
         /* 17-Aug-2013, tatu: One important special case first: if we have one "XML Text"
          * property, it may be exposed as VALUE_STRING token (depending on whether any attribute
          * values are exposed): and to deserialize from that, we need special handling unless POJO
          * has appropriate single-string creator method.
          */
-        BeanDeserializerBase deser = (BeanDeserializerBase) deser0;
-
         // Heuristics are bit tricky; but for now let's assume that if POJO
         // can already work with VALUE_STRING, it's ok and doesn't need extra support
         ValueInstantiator inst = deser.getValueInstantiator();
@@ -108,6 +124,31 @@ public class XmlBeanDeserializerModifier
             }
         }
         return new WrapperHandlingDeserializer(deser);
+    }
+
+    /**
+     * Recursively walks a {@link DelegatingDeserializer} chain to find a
+     * {@link BeanDeserializerBase} at the bottom, applies XML-specific
+     * modifications (wrapper handling / XML text), and rebuilds the delegation
+     * chain from the inside out so no intermediate delegators are lost.
+     */
+    private ValueDeserializer<?> _modifyThroughDelegation(DeserializationConfig config,
+            DelegatingDeserializer deser)
+    {
+        ValueDeserializer<?> delegatee = deser.getDelegatee();
+        ValueDeserializer<?> modifiedDelegatee;
+        if (delegatee instanceof BeanDeserializerBase) {
+            modifiedDelegatee = _modifyBeanDeserializer(config, (BeanDeserializerBase) delegatee);
+        } else if (delegatee instanceof DelegatingDeserializer) {
+            modifiedDelegatee = _modifyThroughDelegation(config, (DelegatingDeserializer) delegatee);
+        } else {
+            // Delegatee is not a type we can handle
+            return deser;
+        }
+        if (modifiedDelegatee != delegatee) {
+            return deser.replaceDelegatee(modifiedDelegatee);
+        }
+        return deser;
     }
 
     private SettableBeanProperty _findSoleTextProp(DeserializationConfig config,

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
@@ -81,21 +81,22 @@ public class XmlBeanDeserializerModifier
 
     @Override
     public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config,
-            BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deser0)
+            BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deser)
     {
-        if (deser0 instanceof BeanDeserializerBase) {
-            return _modifyBeanDeserializer(config, (BeanDeserializerBase) deser0);
+        if (deser instanceof BeanDeserializerBase bdb) {
+            return _modifyBeanDeserializer(config, bdb);
         }
         // [dataformat-xml#334]: If a user's DeserializerModifier has wrapped the
         //   BeanDeserializer in a DelegatingDeserializer, unwrap to find the
         //   underlying BeanDeserializerBase, process it, and rebuild the chain.
-        if (deser0 instanceof DelegatingDeserializer) {
-            return _modifyThroughDelegation(config, (DelegatingDeserializer) deser0);
+        if (deser instanceof DelegatingDeserializer dd) {
+            return _modifyThroughDelegation(config, dd);
         }
-        return deser0;
+        return deser;
     }
 
-    private ValueDeserializer<?> _modifyBeanDeserializer(DeserializationConfig config,
+    // @since 3.2.0
+    protected ValueDeserializer<?> _modifyBeanDeserializer(DeserializationConfig config,
             BeanDeserializerBase deser)
     {
         /* 17-Aug-2013, tatu: One important special case first: if we have one "XML Text"
@@ -121,15 +122,16 @@ public class XmlBeanDeserializerModifier
         return new WrapperHandlingDeserializer(deser);
     }
 
-    private ValueDeserializer<?> _modifyThroughDelegation(DeserializationConfig config,
+    // @since 3.2.0
+    protected ValueDeserializer<?> _modifyThroughDelegation(DeserializationConfig config,
             DelegatingDeserializer deser)
     {
         ValueDeserializer<?> delegatee = deser.getDelegatee();
         ValueDeserializer<?> modifiedDelegatee;
-        if (delegatee instanceof BeanDeserializerBase) {
-            modifiedDelegatee = _modifyBeanDeserializer(config, (BeanDeserializerBase) delegatee);
-        } else if (delegatee instanceof DelegatingDeserializer) {
-            modifiedDelegatee = _modifyThroughDelegation(config, (DelegatingDeserializer) delegatee);
+        if (delegatee instanceof BeanDeserializerBase bdb) {
+            modifiedDelegatee = _modifyBeanDeserializer(config, bdb);
+        } else if (delegatee instanceof DelegatingDeserializer dd) {
+            modifiedDelegatee = _modifyThroughDelegation(config, dd);
         } else {
             // Delegatee is not a type we can handle
             return deser;

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
@@ -95,11 +95,6 @@ public class XmlBeanDeserializerModifier
         return deser0;
     }
 
-    /**
-     * Core modification logic extracted so it can be applied both to direct
-     * {@link BeanDeserializerBase} instances and to ones found inside
-     * {@link DelegatingDeserializer} wrappers.
-     */
     private ValueDeserializer<?> _modifyBeanDeserializer(DeserializationConfig config,
             BeanDeserializerBase deser)
     {
@@ -126,12 +121,6 @@ public class XmlBeanDeserializerModifier
         return new WrapperHandlingDeserializer(deser);
     }
 
-    /**
-     * Recursively walks a {@link DelegatingDeserializer} chain to find a
-     * {@link BeanDeserializerBase} at the bottom, applies XML-specific
-     * modifications (wrapper handling / XML text), and rebuilds the delegation
-     * chain from the inside out so no intermediate delegators are lost.
-     */
     private ValueDeserializer<?> _modifyThroughDelegation(DeserializationConfig config,
             DelegatingDeserializer deser)
     {

--- a/src/test/java/tools/jackson/dataformat/xml/lists/UnwrappedListWithDelegating334Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/lists/UnwrappedListWithDelegating334Test.java
@@ -1,0 +1,121 @@
+package tools.jackson.dataformat.xml.lists;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import tools.jackson.databind.*;
+import tools.jackson.databind.deser.*;
+import tools.jackson.databind.deser.std.DelegatingDeserializer;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.annotation.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for [dataformat-xml#334]: {@code @JacksonXmlElementWrapper(useWrapping = false)}
+ * should work even when a user-provided {@link ValueDeserializerModifier} wraps the
+ * bean deserializer in a {@link DelegatingDeserializer}.
+ */
+public class UnwrappedListWithDelegating334Test extends XmlTestUtil
+{
+    @JsonRootName("batch")
+    static class Batch {
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JacksonXmlProperty(localName = "message")
+        public List<Message> messages;
+    }
+
+    static class Message {
+        @JacksonXmlProperty(localName = "text")
+        public String text;
+    }
+
+    // Minimal DelegatingDeserializer that just passes through
+    static class PassthroughDeserializer extends DelegatingDeserializer {
+        public PassthroughDeserializer(ValueDeserializer<?> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> newDelegatee) {
+            return new PassthroughDeserializer(newDelegatee);
+        }
+    }
+
+    // Modifier that wraps every deserializer in a PassthroughDeserializer
+    static class WrappingModifier extends ValueDeserializerModifier {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config,
+                BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deserializer) {
+            return new PassthroughDeserializer(deserializer);
+        }
+    }
+
+    // Another passthrough, to test multi-level delegation chains
+    static class AnotherPassthroughDeserializer extends DelegatingDeserializer {
+        public AnotherPassthroughDeserializer(ValueDeserializer<?> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> newDelegatee) {
+            return new AnotherPassthroughDeserializer(newDelegatee);
+        }
+    }
+
+    // Modifier that double-wraps: Passthrough -> AnotherPassthrough -> original
+    static class DoubleWrappingModifier extends ValueDeserializerModifier {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config,
+                BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deserializer) {
+            return new PassthroughDeserializer(
+                    new AnotherPassthroughDeserializer(deserializer));
+        }
+    }
+
+    private final XmlMapper MAPPER = XmlMapper.builder()
+            .addModule(new SimpleModule("test")
+                    .setDeserializerModifier(new WrappingModifier()))
+            .build();
+
+    private final XmlMapper MAPPER_DOUBLE = XmlMapper.builder()
+            .addModule(new SimpleModule("test")
+                    .setDeserializerModifier(new DoubleWrappingModifier()))
+            .build();
+
+    private final String BATCH_XML = "<batch>"
+            + "<message><text>one</text></message>"
+            + "<message><text>two</text></message>"
+            + "</batch>";
+
+    @Test
+    public void testUnwrappedListWithDelegatingDeserializer() throws Exception
+    {
+        Batch batch = MAPPER.readValue(BATCH_XML, Batch.class);
+        assertNotNull(batch);
+        assertNotNull(batch.messages);
+        assertEquals(2, batch.messages.size());
+        assertEquals("one", batch.messages.get(0).text);
+        assertEquals("two", batch.messages.get(1).text);
+    }
+
+    @Test
+    public void testUnwrappedListWithMultiLevelDelegation() throws Exception
+    {
+        Batch batch = MAPPER_DOUBLE.readValue(BATCH_XML, Batch.class);
+        assertNotNull(batch);
+        assertNotNull(batch.messages);
+        assertEquals(2, batch.messages.size());
+        assertEquals("one", batch.messages.get(0).text);
+        assertEquals("two", batch.messages.get(1).text);
+    }
+}

--- a/src/test/java/tools/jackson/dataformat/xml/lists/UnwrappedListWithDelegating334Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/lists/UnwrappedListWithDelegating334Test.java
@@ -58,60 +58,19 @@ public class UnwrappedListWithDelegating334Test extends XmlTestUtil
         }
     }
 
-    // Another passthrough, to test multi-level delegation chains
-    static class AnotherPassthroughDeserializer extends DelegatingDeserializer {
-        public AnotherPassthroughDeserializer(ValueDeserializer<?> delegate) {
-            super(delegate);
-        }
-
-        @Override
-        protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> newDelegatee) {
-            return new AnotherPassthroughDeserializer(newDelegatee);
-        }
-    }
-
-    // Modifier that double-wraps: Passthrough -> AnotherPassthrough -> original
-    static class DoubleWrappingModifier extends ValueDeserializerModifier {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config,
-                BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deserializer) {
-            return new PassthroughDeserializer(
-                    new AnotherPassthroughDeserializer(deserializer));
-        }
-    }
-
     private final XmlMapper MAPPER = XmlMapper.builder()
             .addModule(new SimpleModule("test")
                     .setDeserializerModifier(new WrappingModifier()))
             .build();
 
-    private final XmlMapper MAPPER_DOUBLE = XmlMapper.builder()
-            .addModule(new SimpleModule("test")
-                    .setDeserializerModifier(new DoubleWrappingModifier()))
-            .build();
-
-    private final String BATCH_XML = "<batch>"
-            + "<message><text>one</text></message>"
-            + "<message><text>two</text></message>"
-            + "</batch>";
-
     @Test
     public void testUnwrappedListWithDelegatingDeserializer() throws Exception
     {
-        Batch batch = MAPPER.readValue(BATCH_XML, Batch.class);
-        assertNotNull(batch);
-        assertNotNull(batch.messages);
-        assertEquals(2, batch.messages.size());
-        assertEquals("one", batch.messages.get(0).text);
-        assertEquals("two", batch.messages.get(1).text);
-    }
-
-    @Test
-    public void testUnwrappedListWithMultiLevelDelegation() throws Exception
-    {
-        Batch batch = MAPPER_DOUBLE.readValue(BATCH_XML, Batch.class);
+        String xml = "<batch>"
+                + "<message><text>one</text></message>"
+                + "<message><text>two</text></message>"
+                + "</batch>";
+        Batch batch = MAPPER.readValue(xml, Batch.class);
         assertNotNull(batch);
         assertNotNull(batch.messages);
         assertEquals(2, batch.messages.size());


### PR DESCRIPTION
Fixes #334.