### PR TITLE
Re-apply entity/DTD hardening after JDK deserialization of `XmlFactory`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -154,5 +154,8 @@ Christian Beikov (@beikov)
   (3.3.0)
 
 @Sahana2524
- * Fixed #879:  Use `Locale.ROOT` for case folding in `CaseInsensitiveNameSet`
+ * Fixed #878: Re-apply entity/DTD hardening after JDK deserialization of
+   `XmlFactory`
+  (3.3.0)
+ * Fixed #879: Use `Locale.ROOT` for case folding in `CaseInsensitiveNameSet`
   (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -9,6 +9,8 @@ Version: 3.x (for earlier see VERSION-2.x)
 
 #873: Fix handling of `@JsonApplyView`
  (fix by @cowtowncoder, w/ Claude code)
+#878: Re-apply entity/DTD hardening after JDK deserialization of `XmlFactory`
+ (fix by @Sahana2524)
 #879: Use `Locale.ROOT` for case folding in `CaseInsensitiveNameSet`
  (fix by @Sahana2524)
 

--- a/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
@@ -240,7 +240,12 @@ public class XmlFactory
         final XMLInputFactory inf;
         final XMLOutputFactory outf;
         try {
-            inf = (XMLInputFactory) Class.forName(_jdkXmlInFactory).getDeclaredConstructor().newInstance();
+            // Only the factory class name survives serialization, so we get a bare
+            // default instance back: re-apply the entity/DTD hardening the builder
+            // would have set, otherwise a securely-built factory comes back with
+            // external entity + DTD processing re-enabled (see [dataformat-xml#190]/#211).
+            inf = XmlFactoryBuilder.secureXmlInputFactory(
+                    (XMLInputFactory) Class.forName(_jdkXmlInFactory).getDeclaredConstructor().newInstance());
             outf = (XMLOutputFactory) Class.forName(_jdkXmlOutFactory).getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new IllegalArgumentException(e);

--- a/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
@@ -243,7 +243,7 @@ public class XmlFactory
             // Only the factory class name survives serialization, so we get a bare
             // default instance back: re-apply the entity/DTD hardening the builder
             // would have set, otherwise a securely-built factory comes back with
-            // external entity + DTD processing re-enabled (see [dataformat-xml#190]/#211).
+            // external entity + DTD processing re-enabled (see [dataformat-xml#190], [dataformat-xml#211]).
             inf = XmlFactoryBuilder.secureXmlInputFactory(
                     (XMLInputFactory) Class.forName(_jdkXmlInFactory).getDeclaredConstructor().newInstance());
             outf = (XMLOutputFactory) Class.forName(_jdkXmlOutFactory).getDeclaredConstructor().newInstance();

--- a/src/main/java/tools/jackson/dataformat/xml/XmlFactoryBuilder.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlFactoryBuilder.java
@@ -119,6 +119,17 @@ public class XmlFactoryBuilder extends DecorableTSFBuilder<XmlFactory, XmlFactor
             // 24-Oct-2022, tatu: as per [dataformat-xml#550] need extra care
             xmlIn = XMLInputFactory.newFactory();
         }
+        return secureXmlInputFactory(xmlIn);
+    }
+
+    /**
+     * Applies the default entity/DTD hardening to a freshly created
+     * {@link XMLInputFactory}. Shared so that any code path building a factory
+     * internally (including JDK-deserialization reconstruction in
+     * {@code XmlFactory.readResolve()}) applies the same protections and the two
+     * can not drift apart.
+     */
+    protected static XMLInputFactory secureXmlInputFactory(XMLInputFactory xmlIn) {
         // as per [dataformat-xml#190], disable external entity expansion by default
         xmlIn.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         // and ditto wrt [dataformat-xml#211], SUPPORT_DTD

--- a/src/main/java/tools/jackson/dataformat/xml/XmlFactoryBuilder.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlFactoryBuilder.java
@@ -128,6 +128,8 @@ public class XmlFactoryBuilder extends DecorableTSFBuilder<XmlFactory, XmlFactor
      * internally (including JDK-deserialization reconstruction in
      * {@code XmlFactory.readResolve()}) applies the same protections and the two
      * can not drift apart.
+     *
+     * @since 3.3
      */
     protected static XMLInputFactory secureXmlInputFactory(XMLInputFactory xmlIn) {
         // as per [dataformat-xml#190], disable external entity expansion by default

--- a/src/test/java/tools/jackson/dataformat/xml/misc/DTDAfterSerializationTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/misc/DTDAfterSerializationTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 
@@ -33,8 +34,11 @@ public class DTDAfterSerializationTest extends XmlTestUtil
     public void testDTDStaysDisabledAfterRoundtrip() throws Exception
     {
         XmlMapper mapper = jdkRoundtrip(new XmlMapper());
-        // Before the fix the reconstructed factory had DTD/entity processing
-        // re-enabled, so this would expand `&x;` instead of failing.
-        assertThrows(Exception.class, () -> mapper.readValue(ENTITY_XML, Map.class));
+        // Must fail specifically because the parser refuses the DTD-declared
+        // entity (DTD support off), leaving `&x;` unexpanded -- not for some
+        // unrelated binding reason. Before the fix this expanded to "HELLO".
+        StreamReadException e = assertThrows(StreamReadException.class,
+                () -> mapper.readValue(ENTITY_XML, Map.class));
+        verifyException(e, "Undeclared general entity", "entity");
     }
 }

--- a/src/test/java/tools/jackson/dataformat/xml/misc/DTDAfterSerializationTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/misc/DTDAfterSerializationTest.java
@@ -1,0 +1,40 @@
+package tools.jackson.dataformat.xml.misc;
+
+import java.io.*;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+// [dataformat-xml]: entity/DTD hardening must survive JDK serialization of the mapper
+public class DTDAfterSerializationTest extends XmlTestUtil
+{
+    // Internal entity that only expands when DTD processing is enabled
+    private static final String ENTITY_XML =
+            "<?xml version='1.0'?><!DOCTYPE foo [ <!ENTITY x \"HELLO\"> ]>\n"
+            + "<foo>&x;</foo>";
+
+    private XmlMapper jdkRoundtrip(XmlMapper mapper) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream os = new ObjectOutputStream(bytes)) {
+            os.writeObject(mapper);
+        }
+        try (ObjectInputStream is = new ObjectInputStream(
+                new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (XmlMapper) is.readObject();
+        }
+    }
+
+    @Test
+    public void testDTDStaysDisabledAfterRoundtrip() throws Exception
+    {
+        XmlMapper mapper = jdkRoundtrip(new XmlMapper());
+        // Before the fix the reconstructed factory had DTD/entity processing
+        // re-enabled, so this would expand `&x;` instead of failing.
+        assertThrows(Exception.class, () -> mapper.readValue(ENTITY_XML, Map.class));
+    }
+}


### PR DESCRIPTION
**Entity/DTD hardening dropped after JDK deserialization**

`XmlFactory.readResolve()` rebuilds the `XMLInputFactory` from only its stored class name, so the reconstructed factory comes back at plain Stax defaults with external-entity and DTD processing enabled again. A mapper that was safe by default silently regains the entity-expansion/XXE surface after a serialize then deserialize roundtrip. I moved the builder's hardening into a small shared helper and call it from `readResolve` so the two factory-building paths can't drift.

Reproduces with a stock `new XmlMapper()`: reading `<!DOCTYPE foo [ <!ENTITY x "HELLO"> ]><foo>&x;</foo>` throws before serialization, but after a JDK roundtrip `&x;` expands to `HELLO`. Added a regression test alongside the existing serialization/DTD tests.