### PR TITLE
Use `Locale.ROOT` for case folding in `CaseInsensitiveNameSet`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -152,3 +152,7 @@ Christian Beikov (@beikov)
  * Reported #871: `XmlMapper` regression in 3.2.0: `xsi:nil` collection element on
    unwrapped collection wrongly read as null collection
   (3.3.0)
+
+@Sahana2524
+ * Fixed #879:  Use `Locale.ROOT` for case folding in `CaseInsensitiveNameSet`
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -9,6 +9,8 @@ Version: 3.x (for earlier see VERSION-2.x)
 
 #873: Fix handling of `@JsonApplyView`
  (fix by @cowtowncoder, w/ Claude code)
+#879: Use `Locale.ROOT` for case folding in `CaseInsensitiveNameSet`
+ (fix by @Sahana2524)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/dataformat/xml/util/CaseInsensitiveNameSet.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/CaseInsensitiveNameSet.java
@@ -19,7 +19,7 @@ public final class CaseInsensitiveNameSet extends AbstractSet<String>
     public static CaseInsensitiveNameSet construct(Set<String> names0) {
         Set<String> namesToMatch = new HashSet<String>(names0);
         for (String name : names0) {
-            namesToMatch.add(name.toLowerCase());
+            namesToMatch.add(name.toLowerCase(Locale.ROOT));
         }
         return new CaseInsensitiveNameSet(namesToMatch);
     }
@@ -30,7 +30,7 @@ public final class CaseInsensitiveNameSet extends AbstractSet<String>
         if (_namesToMatch.contains(key)) {
             return true;
         }
-        final String lc = key.toLowerCase();
+        final String lc = key.toLowerCase(Locale.ROOT);
         return (lc != key) && _namesToMatch.contains(lc);
     }
 

--- a/src/test/java/tools/jackson/dataformat/xml/util/CaseInsensitiveNameSetTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/util/CaseInsensitiveNameSetTest.java
@@ -4,16 +4,23 @@ import java.util.Collections;
 import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+
+import tools.jackson.dataformat.xml.XmlTestUtil;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CaseInsensitiveNameSetTest
+public class CaseInsensitiveNameSetTest extends XmlTestUtil
 {
     // Names with 'I'/'i' fold differently under the Turkish locale
     // ("I".toLowerCase() -> dotless "ı"), so a set built with the default
     // locale would stop matching them. Matching should not depend on the JVM's
     // default locale.
     @Test
+    // Mutates JVM-wide default Locale: needs exclusive access in case tests
+    // are ever run in parallel
+    @ResourceLock(Resources.LOCALE)
     public void testMatchingIndependentOfDefaultLocale()
     {
         final Locale orig = Locale.getDefault();

--- a/src/test/java/tools/jackson/dataformat/xml/util/CaseInsensitiveNameSetTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/util/CaseInsensitiveNameSetTest.java
@@ -1,0 +1,35 @@
+package tools.jackson.dataformat.xml.util;
+
+import java.util.Collections;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CaseInsensitiveNameSetTest
+{
+    // Names with 'I'/'i' fold differently under the Turkish locale
+    // ("I".toLowerCase() -> dotless "ı"), so a set built with the default
+    // locale would stop matching them. Matching should not depend on the JVM's
+    // default locale.
+    @Test
+    public void testMatchingIndependentOfDefaultLocale()
+    {
+        final Locale orig = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+
+            CaseInsensitiveNameSet set = CaseInsensitiveNameSet.construct(
+                    Collections.singleton("ITEM"));
+            assertTrue(set.contains("item"),
+                    "case-insensitive match of 'item' against 'ITEM' should hold under any locale");
+
+            set = CaseInsensitiveNameSet.construct(Collections.singleton("title"));
+            assertTrue(set.contains("TITLE"),
+                    "case-insensitive match of 'TITLE' against 'title' should hold under any locale");
+        } finally {
+            Locale.setDefault(orig);
+        }
+    }
+}


### PR DESCRIPTION
`CaseInsensitiveNameSet` folds names with the JVM default locale, so case-insensitive element matching quietly breaks for names containing `I`/`i` once the default is a locale like Turkish:
- `construct()` and `contains()` both call `String.toLowerCase()` with no locale, so a wrapper name like `ITEM` stops matching an incoming `item` when the default locale is `tr` (`"ITEM".toLowerCase()` becomes dotless `ıtem`)
- the names being matched are element/attribute names from the parsed document, and this feeds unwrapped-list wrapping via `FromXmlParser.addVirtualWrapping` when `ACCEPT_CASE_INSENSITIVE_PROPERTIES` is on, so the result ends up depending on server locale
- `XmlTokenBuffer` already matches the same names with `equalsIgnoreCase`, which is locale independent, so this helper is the odd one out

Both calls now use `Locale.ROOT`. Pure-ASCII names, the common case, are unchanged.
