### PR TITLE
Escape names already starting with prefix in `Base64NameProcessor`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -168,3 +168,5 @@ Christian Beikov (@beikov)
   (3.3.0)
  * Fixed #883: Translate `XMLStreamReader` creation errors to `StreamReadException`
   (3.3.0)
+ * Fixed #886: Escape names already starting with prefix in `Base64NameProcessor`
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -18,6 +18,8 @@ Version: 3.x (for earlier see VERSION-2.x)
 #883: Translate `XMLStreamReader` creation errors to `StreamReadException`
   (restores guard lost in 3.x port; see 2.x `_createParser(byte[])` for #618)
  (fix by @Sahana2524)
+#886: Escape names already starting with prefix in `Base64NameProcessor`
+ (fix by @Sahana2524)
 
 3.2.2 (not yet released)
 

--- a/src/main/java/tools/jackson/dataformat/xml/XmlNameProcessors.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlNameProcessors.java
@@ -1,6 +1,7 @@
 package tools.jackson.dataformat.xml;
 
 import java.util.Base64;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -167,7 +168,9 @@ public final class XmlNameProcessors
         private final String _replacement;
 
         public ReplaceNameProcessor(String replacement) {
-            _replacement = replacement;
+            // Only used as replaceAll() argument, so a null one would otherwise
+            // only fail on the first name written: fail here instead
+            _replacement = Objects.requireNonNull(replacement, "replacement cannot be null");
         }
 
         @Override
@@ -193,7 +196,9 @@ public final class XmlNameProcessors
         private final String _prefix;
 
         public Base64NameProcessor(String prefix) {
-            _prefix = prefix;
+            // Both encodeName() and decodeName() test names against the prefix, so
+            // a null one would only fail deep inside name handling: fail here instead
+            _prefix = Objects.requireNonNull(prefix, "prefix cannot be null");
         }
 
         @Override

--- a/src/main/java/tools/jackson/dataformat/xml/XmlNameProcessors.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlNameProcessors.java
@@ -118,8 +118,9 @@ public final class XmlNameProcessors
      * </DTO>
      * }</pre>
      *<p>
-     * NOTE: you must ensure that no incoming element or attribute name starts
-     * with {@code prefix}, otherwise decoding will not work.
+     * NOTE: names that already start with {@code prefix} are escaped as well, even
+     * though they are otherwise valid, so that decoding cannot confuse them with
+     * names this processor encoded.
      *
      * @param prefix The prefix to use for name that are escaped
      */
@@ -197,7 +198,12 @@ public final class XmlNameProcessors
 
         @Override
         public void encodeName(XmlName name) {
-            if (!VALID_XML_NAME.matcher(name.localPart).matches()) {
+            // Names already starting with the prefix have to be escaped as well, even
+            // when otherwise valid: decodeName() base64-decodes anything carrying the
+            // prefix, so passing such a name through as-is would decode it into a
+            // different name than was written.
+            if (!VALID_XML_NAME.matcher(name.localPart).matches()
+                    || name.localPart.startsWith(_prefix)) {
                 name.localPart = _prefix + new String(BASE64_ENCODER.encode(name.localPart.getBytes(UTF_8)), UTF_8);
             }
         }

--- a/src/test/java/tools/jackson/dataformat/xml/misc/XmlNameEscapeTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/misc/XmlNameEscapeTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // For [dataformat-xml#531]
 public class XmlNameEscapeTest extends XmlTestUtil
@@ -172,12 +173,18 @@ public class XmlNameEscapeTest extends XmlTestUtil
         ).build();
 
         final String res = mapper.writeValueAsString(dto);
+        // Prefixed names get escaped...
+        assertTrue(res.contains("base64_tag_YmFzZTY0X3RhZ19ZV1J0YVc0"), res);
+        assertTrue(res.contains("base64_tag_YmFzZTY0X3RhZ19oZWxsbw"), res);
+        // ... but ordinary valid names still pass through as-is
+        assertTrue(res.contains("<plain>abc</plain>"), res);
+
         DTO reversed = mapper.readValue(res, DTO.class);
         assertEquals(dto, reversed);
     }
 
     @Test
-    public void testBase64CustomPrefixedNameRoundTrips() throws Exception {
+    public void testBase64CustomPrefixedNameRoundTrip() throws Exception {
         DTO dto = new DTO();
         dto.badMap.put("esc_YWRtaW4", "xyz");
 
@@ -186,6 +193,8 @@ public class XmlNameEscapeTest extends XmlTestUtil
         ).build();
 
         final String res = mapper.writeValueAsString(dto);
+        assertTrue(res.contains("esc_ZXNjX1lXUnRhVzQ"), res);
+
         DTO reversed = mapper.readValue(res, DTO.class);
         assertEquals(dto, reversed);
     }

--- a/src/test/java/tools/jackson/dataformat/xml/misc/XmlNameEscapeTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/misc/XmlNameEscapeTest.java
@@ -154,6 +154,42 @@ public class XmlNameEscapeTest extends XmlTestUtil
         assertNotEquals(TokenStreamLocation.NA, e.getLocation());
     }
 
+    // A name that is a valid XML name but already starts with the magic prefix has
+    // to be escaped too: decoding keys off that prefix, so writing such a name
+    // through as-is makes it read back as a different name than was written.
+    @Test
+    public void testBase64PrefixedNamesRoundTrip() throws Exception {
+        DTO dto = new DTO();
+
+        // would otherwise read back as "admin"
+        dto.badMap.put("base64_tag_YWRtaW4", "xyz");
+        // valid XML name, but not valid base64 past the prefix
+        dto.badMap.put("base64_tag_hello", "bar");
+        dto.badMap.put("plain", "abc");
+
+        XmlMapper mapper = XmlMapper.builder(
+                xmlFactory(XmlNameProcessors.newBase64Processor())
+        ).build();
+
+        final String res = mapper.writeValueAsString(dto);
+        DTO reversed = mapper.readValue(res, DTO.class);
+        assertEquals(dto, reversed);
+    }
+
+    @Test
+    public void testBase64CustomPrefixedNameRoundTrips() throws Exception {
+        DTO dto = new DTO();
+        dto.badMap.put("esc_YWRtaW4", "xyz");
+
+        XmlMapper mapper = XmlMapper.builder(
+                xmlFactory(XmlNameProcessors.newBase64Processor("esc_"))
+        ).build();
+
+        final String res = mapper.writeValueAsString(dto);
+        DTO reversed = mapper.readValue(res, DTO.class);
+        assertEquals(dto, reversed);
+    }
+
     protected XmlFactory xmlFactory(XmlNameProcessor proc) {
         return XmlFactory.builder().xmlNameProcessor(proc).build();
     }

--- a/src/test/java/tools/jackson/dataformat/xml/misc/XmlNameEscapeTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/misc/XmlNameEscapeTest.java
@@ -199,6 +199,19 @@ public class XmlNameEscapeTest extends XmlTestUtil
         assertEquals(dto, reversed);
     }
 
+    // Null prefix/replacement would otherwise only blow up deep inside name handling
+    @Test
+    public void testBase64NullPrefixFailsAtConstruction() throws Exception {
+        assertThrows(NullPointerException.class,
+                () -> XmlNameProcessors.newBase64Processor(null));
+    }
+
+    @Test
+    public void testReplacementNullFailsAtConstruction() throws Exception {
+        assertThrows(NullPointerException.class,
+                () -> XmlNameProcessors.newReplacementProcessor(null));
+    }
+
     protected XmlFactory xmlFactory(XmlNameProcessor proc) {
         return XmlFactory.builder().xmlNameProcessor(proc).build();
     }


### PR DESCRIPTION
The prefixed base64 name processor escapes on write but decodes on read using different conditions, so a name that already starts with the prefix does not survive a round-trip:

- `encodeName()` escapes only names that fail `VALID_XML_NAME`, so `base64_tag_YWRtaW4` is a valid XML name and goes out as-is
- `decodeName()` decodes anything starting with the prefix, so that same name reads back as `admin`
- when the remainder is not valid base64 (`base64_tag_hello`) the read fails instead, which is how I noticed it

Escaping prefixed names too makes the decode-side prefix test exact, so the mapping is one-to-one again. Names that do not start with the prefix encode exactly as before. The javadoc had this as a caller obligation ("you must ensure that no incoming element or attribute name starts with prefix") - that seemed worth moving into the processor, since with map keys the names are usually not the caller's to choose. Left `AlwaysOnBase64NameProcessor` alone: it encodes and decodes every name, so it is already symmetric.