### PR TITLE
Apply `XmlNameProcessor` to unwrapped `ObjectNode` root element name

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -168,3 +168,6 @@ Christian Beikov (@beikov)
   (3.3.0)
  * Fixed #883: Translate `XMLStreamReader` creation errors to `StreamReadException`
   (3.3.0)
+ * Fixed #887: Apply `XmlNameProcessor` to unwrapped `ObjectNode` root element
+   name
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -18,6 +18,8 @@ Version: 3.x (for earlier see VERSION-2.x)
 #883: Translate `XMLStreamReader` creation errors to `StreamReadException`
   (restores guard lost in 3.x port; see 2.x `_createParser(byte[])` for #618)
  (fix by @Sahana2524)
+#887: Apply `XmlNameProcessor` to unwrapped `ObjectNode` root element name
+ (fix by @Sahana2524)
 
 3.2.2 (not yet released)
 

--- a/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -520,10 +520,11 @@ public class ToXmlGenerator
     
     /**
      * Method for running configured {@link XmlNameProcessor} over a name that comes
-     * from content being written (like {@code Map} keys or {@code ObjectNode} property
-     * names), as opposed to statically known POJO property names.
+     * from content being written (like {@code ObjectNode} property names), as opposed
+     * to statically known POJO property names.
      * Needed by callers that have to construct the {@link QName} themselves instead
-     * of going through {@link #writeName(String)}.
+     * of going through {@link #writeName(String)} (which applies the processor for
+     * names it writes).
      *
      * @since 3.3
      */
@@ -608,7 +609,6 @@ public class ToXmlGenerator
             _reportError("Can not write a property name, expecting a value");
         }
 
-        String ns;
         // 30-Jan-2024, tatu: Surprise!
         if (XmlWriteFeature.AUTO_DETECT_XSI_TYPE.enabledIn(_formatFeatures)
                 && "xsi:type".equals(name)) {
@@ -629,7 +629,7 @@ public class ToXmlGenerator
             }
         } else {
             // Should this ever get called?
-            ns = (_nextName == null) ? "" : _nextName.getNamespaceURI();
+            String ns = (_nextName == null) ? "" : _nextName.getNamespaceURI();
             setNextName(encodeContentName(ns, name));
         }
         return this;

--- a/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -519,6 +519,23 @@ public class ToXmlGenerator
     }
     
     /**
+     * Method for running configured {@link XmlNameProcessor} over a name that comes
+     * from content being written (like {@code Map} keys or {@code ObjectNode} property
+     * names), as opposed to statically known POJO property names.
+     * Needed by callers that have to construct the {@link QName} themselves instead
+     * of going through {@link #writeName(String)}.
+     *
+     * @since 3.3
+     */
+    public QName encodeContentName(String namespaceURI, String localName)
+    {
+        _nameToEncode.namespace = (namespaceURI == null) ? "" : namespaceURI;
+        _nameToEncode.localPart = localName;
+        _nameProcessor.encodeName(_nameToEncode);
+        return new QName(_nameToEncode.namespace, _nameToEncode.localPart);
+    }
+
+    /**
      * Methdod called when a structured (collection, array, map) is being
      * output.
      * 
@@ -613,10 +630,7 @@ public class ToXmlGenerator
         } else {
             // Should this ever get called?
             ns = (_nextName == null) ? "" : _nextName.getNamespaceURI();
-            _nameToEncode.namespace = ns;
-            _nameToEncode.localPart = name;
-            _nameProcessor.encodeName(_nameToEncode);
-            setNextName(new QName(_nameToEncode.namespace, _nameToEncode.localPart));
+            setNextName(encodeContentName(ns, name));
         }
         return this;
     }

--- a/src/main/java/tools/jackson/dataformat/xml/ser/XmlSerializationContext.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/XmlSerializationContext.java
@@ -275,8 +275,10 @@ public class XmlSerializationContext extends SerializationContextExt
         Map.Entry<String, JsonNode> entry = root.properties().iterator().next();
         final JsonNode newRoot = entry.getValue();
 
+        // Name comes from content, so has to go through the same XmlNameProcessor
+        // the generator applies to other content-derived names.
         // No namespace associated with JsonNode:
-        _initWithRootName(xgen, new QName(entry.getKey()));
+        _initWithRootName(xgen, xgen.encodeContentName("", entry.getKey()));
         if (ser == null) {
             ser = findTypedValueSerializer(newRoot.getClass(), true);
         }

--- a/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeSerRootName887Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeSerRootName887Test.java
@@ -1,0 +1,60 @@
+package tools.jackson.dataformat.xml.node;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.node.ObjectNode;
+
+import tools.jackson.dataformat.xml.XmlFactory;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlNameProcessor;
+import tools.jackson.dataformat.xml.XmlNameProcessors;
+import tools.jackson.dataformat.xml.XmlReadFeature;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// [dataformat-xml#887]: root name of unwrapped `ObjectNode` (see
+// `XmlWriteFeature.UNWRAP_ROOT_OBJECT_NODE`) needs `XmlNameProcessor` handling
+public class JsonNodeSerRootName887Test extends XmlTestUtil
+{
+    // The unwrapped root name comes from content, so it needs the same
+    // XmlNameProcessor treatment the name gets when written as a child element.
+    @Test
+    public void testUnwrappedRootNameIsProcessed() throws Exception
+    {
+        final String BAD_NAME = "$ I am <fancy>! &;";
+        XmlMapper mapper = mapperWith(XmlNameProcessors.newReplacementProcessor());
+
+        ObjectNode oneProp = mapper.createObjectNode();
+        oneProp.putObject(BAD_NAME).put("id", 13);
+
+        ObjectNode twoProps = mapper.createObjectNode();
+        twoProps.putObject(BAD_NAME).put("id", 13);
+        twoProps.put("other", 1);
+
+        assertEquals("<__I_am__fancy_____><id>13</id></__I_am__fancy_____>",
+                mapper.writeValueAsString(oneProp));
+        assertEquals("<ObjectNode><__I_am__fancy_____><id>13</id></__I_am__fancy_____>"
+                +"<other>1</other></ObjectNode>",
+                mapper.writeValueAsString(twoProps));
+    }
+
+    // ... which also makes the WRAP_ROOT_ELEMENT_NAME / UNWRAP_ROOT_OBJECT_NODE
+    // pairing round-trip a root name that had to be escaped
+    @Test
+    public void testUnwrappedRootNameRoundTrip() throws Exception
+    {
+        XmlMapper mapper = mapperWith(XmlNameProcessors.newBase64Processor());
+        // decodes to "$ I am <fancy>! &;"
+        final String DOC = "<base64_tag_JCBJIGFtIDxmYW5jeT4hICY7><id>13</id>"
+                +"</base64_tag_JCBJIGFtIDxmYW5jeT4hICY7>";
+
+        assertEquals(DOC, mapper.writeValueAsString(mapper.readTree(DOC)));
+    }
+
+    private XmlMapper mapperWith(XmlNameProcessor proc) {
+        return mapperBuilder(XmlFactory.builder().xmlNameProcessor(proc).build())
+                .enable(XmlReadFeature.WRAP_ROOT_ELEMENT_NAME)
+                .build();
+    }
+}

--- a/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeSerUnwrapped441Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeSerUnwrapped441Test.java
@@ -9,6 +9,11 @@ import tools.jackson.databind.ObjectWriter;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
+import tools.jackson.dataformat.xml.XmlFactory;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlNameProcessor;
+import tools.jackson.dataformat.xml.XmlNameProcessors;
+import tools.jackson.dataformat.xml.XmlReadFeature;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.XmlWriteFeature;
 
@@ -97,5 +102,46 @@ public class JsonNodeSerUnwrapped441Test extends XmlTestUtil
         assertEquals("<Stuff441><key>value</key></Stuff441>",
                 XML_MAPPER.writeValueAsString(stuff));
                 */
+    }
+
+    // The unwrapped root name comes from content, so it needs the same
+    // XmlNameProcessor treatment the name gets when written as a child element.
+    @Test
+    public void testUnwrappedRootNameIsProcessed() throws Exception
+    {
+        final String BAD_NAME = "$ I am <fancy>! &;";
+        XmlMapper mapper = mapperWith(XmlNameProcessors.newReplacementProcessor());
+
+        ObjectNode oneProp = mapper.createObjectNode();
+        oneProp.putObject(BAD_NAME).put("id", 13);
+
+        ObjectNode twoProps = mapper.createObjectNode();
+        twoProps.putObject(BAD_NAME).put("id", 13);
+        twoProps.put("other", 1);
+
+        assertEquals("<__I_am__fancy_____><id>13</id></__I_am__fancy_____>",
+                mapper.writeValueAsString(oneProp));
+        assertEquals("<ObjectNode><__I_am__fancy_____><id>13</id></__I_am__fancy_____>"
+                +"<other>1</other></ObjectNode>",
+                mapper.writeValueAsString(twoProps));
+    }
+
+    // ... which also makes the WRAP_ROOT_ELEMENT_NAME / UNWRAP_ROOT_OBJECT_NODE
+    // pairing round-trip a root name that had to be escaped
+    @Test
+    public void testUnwrappedRootNameRoundTrip() throws Exception
+    {
+        XmlMapper mapper = mapperWith(XmlNameProcessors.newBase64Processor());
+        // decodes to "$ I am <fancy>! &;"
+        final String DOC = "<base64_tag_JCBJIGFtIDxmYW5jeT4hICY7><id>13</id>"
+                +"</base64_tag_JCBJIGFtIDxmYW5jeT4hICY7>";
+
+        assertEquals(DOC, mapper.writeValueAsString(mapper.readTree(DOC)));
+    }
+
+    private XmlMapper mapperWith(XmlNameProcessor proc) {
+        return mapperBuilder(XmlFactory.builder().xmlNameProcessor(proc).build())
+                .enable(XmlReadFeature.WRAP_ROOT_ELEMENT_NAME)
+                .build();
     }
 }

--- a/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeSerUnwrapped441Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/node/JsonNodeSerUnwrapped441Test.java
@@ -9,11 +9,6 @@ import tools.jackson.databind.ObjectWriter;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
-import tools.jackson.dataformat.xml.XmlFactory;
-import tools.jackson.dataformat.xml.XmlMapper;
-import tools.jackson.dataformat.xml.XmlNameProcessor;
-import tools.jackson.dataformat.xml.XmlNameProcessors;
-import tools.jackson.dataformat.xml.XmlReadFeature;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.XmlWriteFeature;
 
@@ -102,46 +97,5 @@ public class JsonNodeSerUnwrapped441Test extends XmlTestUtil
         assertEquals("<Stuff441><key>value</key></Stuff441>",
                 XML_MAPPER.writeValueAsString(stuff));
                 */
-    }
-
-    // The unwrapped root name comes from content, so it needs the same
-    // XmlNameProcessor treatment the name gets when written as a child element.
-    @Test
-    public void testUnwrappedRootNameIsProcessed() throws Exception
-    {
-        final String BAD_NAME = "$ I am <fancy>! &;";
-        XmlMapper mapper = mapperWith(XmlNameProcessors.newReplacementProcessor());
-
-        ObjectNode oneProp = mapper.createObjectNode();
-        oneProp.putObject(BAD_NAME).put("id", 13);
-
-        ObjectNode twoProps = mapper.createObjectNode();
-        twoProps.putObject(BAD_NAME).put("id", 13);
-        twoProps.put("other", 1);
-
-        assertEquals("<__I_am__fancy_____><id>13</id></__I_am__fancy_____>",
-                mapper.writeValueAsString(oneProp));
-        assertEquals("<ObjectNode><__I_am__fancy_____><id>13</id></__I_am__fancy_____>"
-                +"<other>1</other></ObjectNode>",
-                mapper.writeValueAsString(twoProps));
-    }
-
-    // ... which also makes the WRAP_ROOT_ELEMENT_NAME / UNWRAP_ROOT_OBJECT_NODE
-    // pairing round-trip a root name that had to be escaped
-    @Test
-    public void testUnwrappedRootNameRoundTrip() throws Exception
-    {
-        XmlMapper mapper = mapperWith(XmlNameProcessors.newBase64Processor());
-        // decodes to "$ I am <fancy>! &;"
-        final String DOC = "<base64_tag_JCBJIGFtIDxmYW5jeT4hICY7><id>13</id>"
-                +"</base64_tag_JCBJIGFtIDxmYW5jeT4hICY7>";
-
-        assertEquals(DOC, mapper.writeValueAsString(mapper.readTree(DOC)));
-    }
-
-    private XmlMapper mapperWith(XmlNameProcessor proc) {
-        return mapperBuilder(XmlFactory.builder().xmlNameProcessor(proc).build())
-                .enable(XmlReadFeature.WRAP_ROOT_ELEMENT_NAME)
-                .build();
     }
 }


### PR DESCRIPTION
**Root element name skips the configured `XmlNameProcessor`**

With `UNWRAP_ROOT_OBJECT_NODE` (on by default) the root element name is taken from the `ObjectNode` property name and written as-is, so a name that gets escaped when it lands as a child element is not escaped when it lands as the root: `{"$ I am <fancy>! &;": {"id": 13}}` comes out as `<$ I am <fancy>! &;><id>13</id></$ I am <fancy>! &;>`, whereas the same key one level down becomes `<__I_am__fancy_____>`. Since that name comes from content rather than from a POJO property, routing it through the generator's processor seemed like the right layer, and it also makes the `WRAP_ROOT_ELEMENT_NAME` / `UNWRAP_ROOT_OBJECT_NODE` pairing round-trip a root name that had to be escaped, which is what the javadoc promises. Default passthrough processor output is unchanged.
