### PR TITLE
Read stream to end for negative length in `writeBinary(InputStream)`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -290,3 +290,6 @@ Sahana (@Sahana2524)
 * Fixed #899: Return `null` from `nextTextValue()` at end-of-input (instead of
   throwing `IllegalStateException`)
  (2.23.0)
+* Fixed #894: `ToXmlGenerator.writeBinary(Base64Variant, InputStream, int)` fails with
+  `NegativeArraySizeException`/`IndexOutOfBoundsException` for unknown (negative) length
+ (2.23.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -9,6 +9,9 @@ Project: jackson-dataformat-xml
 #899: Return `null` from `nextTextValue()` at end-of-input (instead of
   throwing `IllegalStateException`)
  (fix by @Sahana2524)
+#894: `ToXmlGenerator.writeBinary(Base64Variant, InputStream, int)` fails with
+  `NegativeArraySizeException`/`IndexOutOfBoundsException` for unknown (negative) length
+ (fix by @Sahana2524)
 
 2.22.2 (16-Aug-2026)
 2.22.1 (07-Jul-2026)

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -1068,6 +1068,7 @@ public class ToXmlGenerator
             InputStream data, int len) throws IOException, XMLStreamException 
     {
         final byte[] buf = _ioContext.allocBase64Buffer();
+        final int unit = _base64ChunkUnit(stax2base64v, buf.length);
         int total = 0;
         try {
             int end = 0; // number of buffered bytes not yet written
@@ -1088,9 +1089,8 @@ public class ToXmlGenerator
                 if (len > 0) {
                     len -= count;
                 }
-                // base64 encodes 3 bytes into 4 characters: write complete triplets,
-                // keep the remainder for the next round
-                int full = end - (end % 3);
+                // Write out complete chunks, keep the remainder for the next round
+                int full = end - (end % unit);
                 if (full > 0) {
                     _xmlWriter.writeBinary(stax2base64v, buf, 0, full);
                     end -= full;
@@ -1101,6 +1101,34 @@ public class ToXmlGenerator
             _ioContext.releaseBase64Buffer(buf);
         }
         return total;
+    }
+
+    /**
+     * Helper method for figuring out granularity of chunks to pass to Stax2
+     * {@code writeBinary()}: Base64 encodes 3 bytes into 4 characters so chunk
+     * length must be a multiple of 3. Further, if variant uses linefeeds, chunks
+     * must also align with Base64 line boundaries: Stax2 encoder restarts its
+     * line-length counter for every call, so unaligned chunks would produce
+     * lines longer than the variant allows.
+     *
+     * @param b64v Base64 variant used for encoding
+     * @param bufferLength Length of the read buffer chunks are taken from
+     *
+     * @return Chunk length granularity to use; always a multiple of 3
+     */
+    private static int _base64ChunkUnit(org.codehaus.stax2.typed.Base64Variant b64v,
+            int bufferLength)
+    {
+        final int maxLineLength = b64v.getMaxLineLength();
+        if (maxLineLength > 0 && maxLineLength < Integer.MAX_VALUE) {
+            // 4 encoded characters per each 3 bytes of input
+            final int lineBytes = (maxLineLength >> 2) * 3;
+            // But cannot align if a single line won't fit in the read buffer
+            if (lineBytes >= 3 && lineBytes <= bufferLength) {
+                return lineBytes;
+            }
+        }
+        return 3;
     }
 
     private byte[] toFullBuffer(byte[] data, int offset, int len)

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -1012,6 +1012,18 @@ public class ToXmlGenerator
         }
     }
 
+    /**
+     * Implementation follows the {@link JsonGenerator} contract in which negative
+     * {@code dataLength} means "length unknown": stream is then read until end-of-stream.
+     *<p>
+     * NOTE: values written as XML elements are streamed in fixed-size chunks, but values
+     * written as attributes (or with a pretty-printer) have to be buffered in memory in
+     * full, since Stax2 API only offers "full buffer" methods for those cases.
+     *
+     * @param dataLength Number of bytes to write, if known; negative value if unknown
+     *
+     * @return Number of bytes read from {@code data} and written as binary payload
+     */
     @Override
     public int writeBinary(Base64Variant b64variant, InputStream data, int dataLength) throws IOException
     {
@@ -1060,7 +1072,9 @@ public class ToXmlGenerator
 
     /**
      * Helper method for encoding contents of given stream: at most {@code len}
-     * bytes if non-negative, or until end-of-stream if negative.
+     * bytes if non-negative, or until end-of-stream if negative. Content is read
+     * and encoded in fixed-size chunks so memory usage does not depend on its length;
+     * preferred over {@link #toFullBuffer} where Stax2 API allows it.
      *
      * @return Number of bytes read and encoded
      */
@@ -1105,14 +1119,9 @@ public class ToXmlGenerator
 
     /**
      * Helper method for figuring out granularity of chunks to pass to Stax2
-     * {@code writeBinary()}: Base64 encodes 3 bytes into 4 characters so chunk
-     * length must be a multiple of 3. Further, if variant uses linefeeds, chunks
-     * must also align with Base64 line boundaries: Stax2 encoder restarts its
-     * line-length counter for every call, so unaligned chunks would produce
-     * lines longer than the variant allows.
-     *
-     * @param b64v Base64 variant used for encoding
-     * @param bufferLength Length of the read buffer chunks are taken from
+     * {@code writeBinary()}: Base64 encodes 3 bytes into 4 characters so chunks must
+     * be multiples of 3 -- and if variant uses linefeeds, must also align with line
+     * boundaries, since Stax2 encoder restarts its line-length counter on every call.
      *
      * @return Chunk length granularity to use; always a multiple of 3
      */
@@ -1144,6 +1153,11 @@ public class ToXmlGenerator
         return result;
     }
 
+    /**
+     * Helper method for reading exactly {@code len} bytes into a newly allocated
+     * buffer, for cases where Stax2 API requires the full value; fails if stream
+     * does not contain that many bytes.
+     */
     private byte[] toFullBuffer(InputStream data, final int len) throws IOException 
     {
         byte[] result = new byte[len];
@@ -1159,20 +1173,33 @@ public class ToXmlGenerator
         return result;
     }
 
-    // Variant for "unknown length": read until end-of-stream
+    /**
+     * Variant of {@link #toFullBuffer(InputStream, int)} for unknown length: reads
+     * until end-of-stream.
+     *<p>
+     * NOTE: since length is not known in advance no allocation limit can be applied,
+     * and an arbitrarily large stream is accumulated until exhausted (or memory runs
+     * out); prefer {@link #writeStreamAsBinary} wherever streaming is possible.
+     */
     private byte[] toFullBuffer(InputStream data) throws IOException
     {
-        final ByteArrayBuilder bb = new ByteArrayBuilder(_ioContext.bufferRecycler());
         final byte[] tmp = _ioContext.allocBase64Buffer();
+        final ByteArrayBuilder bb = new ByteArrayBuilder(_ioContext.bufferRecycler());
+        byte[] result = null;
         try {
             int count;
             while ((count = data.read(tmp)) >= 0) {
                 bb.write(tmp, 0, count);
             }
+            result = bb.getClearAndRelease();
         } finally {
             _ioContext.releaseBase64Buffer(tmp);
+            // If read failed, builder still holds on to a recycled buffer: return it
+            if (result == null) {
+                bb.release();
+            }
         }
-        return bb.getClearAndRelease();
+        return result;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.GeneratorBase;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
+import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import com.fasterxml.jackson.core.util.JacksonFeatureSet;
 import com.fasterxml.jackson.dataformat.xml.XmlPrettyPrinter;
 import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter;
@@ -1023,24 +1024,30 @@ public class ToXmlGenerator
             handleMissingName();
         }
         final org.codehaus.stax2.typed.Base64Variant stax2base64v = StaxUtil.toStax2Base64Variant(b64variant);
+        // 22-Aug-2026, sahana: negative `dataLength` means "unknown, read to the end";
+        //   stream where we can, buffer only where Stax2 needs a full buffer
+        int written = dataLength;
         try {
             if (_nextIsAttribute) {
                 // Stax2 API only has 'full buffer' write method:
-                byte[] fullBuffer = toFullBuffer(data, dataLength);
+                byte[] fullBuffer = (dataLength < 0) ? toFullBuffer(data) : toFullBuffer(data, dataLength);
+                written = fullBuffer.length;
                 _xmlWriter.writeBinaryAttribute(stax2base64v,
                         "", _nextName.getNamespaceURI(), _nextName.getLocalPart(), fullBuffer);
             } else if (checkNextIsUnwrapped()) {
               // should we consider pretty-printing or not?
-                writeStreamAsBinary(stax2base64v, data, dataLength);
+                written = writeStreamAsBinary(stax2base64v, data, dataLength);
 
             } else {
                 if (_xmlPrettyPrinter != null) {
+                    byte[] fullBuffer = (dataLength < 0) ? toFullBuffer(data) : toFullBuffer(data, dataLength);
+                    written = fullBuffer.length;
                     _xmlPrettyPrinter.writeLeafElement(_xmlWriter,
                             _nextName.getNamespaceURI(), _nextName.getLocalPart(),
-                            stax2base64v, toFullBuffer(data, dataLength), 0, dataLength);
+                            stax2base64v, fullBuffer, 0, written);
                 } else {
                     _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
-                    writeStreamAsBinary(stax2base64v, data, dataLength);
+                    written = writeStreamAsBinary(stax2base64v, data, dataLength);
                     _xmlWriter.writeEndElement();
                 }
             }
@@ -1048,32 +1055,52 @@ public class ToXmlGenerator
             StaxUtil.throwAsGenerationException(e, this);
         }
 
-        return dataLength;
+        return written;
     }
 
-    private void writeStreamAsBinary(org.codehaus.stax2.typed.Base64Variant stax2base64v,
+    /**
+     * Helper method for encoding contents of given stream: at most {@code len}
+     * bytes if non-negative, or until end-of-stream if negative.
+     *
+     * @return Number of bytes read and encoded
+     */
+    private int writeStreamAsBinary(org.codehaus.stax2.typed.Base64Variant stax2base64v,
             InputStream data, int len) throws IOException, XMLStreamException 
     {
-        // base64 encodes up to 3 bytes into a 4 bytes string
-        byte[] tmp = new byte[3];
-        int offset = 0;
-        int read;
-        while((read = data.read(tmp, offset, Math.min(3 - offset, len))) != -1) {
-            offset += read;
-            len -= read;
-            if(offset == 3) {
-                offset = 0;
-                _xmlWriter.writeBinary(stax2base64v, tmp, 0, 3);
+        final byte[] buf = _ioContext.allocBase64Buffer();
+        int total = 0;
+        try {
+            int end = 0; // number of buffered bytes not yet written
+            while (true) {
+                int max = buf.length - end;
+                if (len >= 0 && len < max) {
+                    max = len;
+                }
+                int count = (max == 0) ? -1 : data.read(buf, end, max);
+                if (count < 0) { // end-of-stream, or requested length reached
+                    if (end > 0) {
+                        _xmlWriter.writeBinary(stax2base64v, buf, 0, end);
+                    }
+                    break;
+                }
+                end += count;
+                total += count;
+                if (len > 0) {
+                    len -= count;
+                }
+                // base64 encodes 3 bytes into 4 characters: write complete triplets,
+                // keep the remainder for the next round
+                int full = end - (end % 3);
+                if (full > 0) {
+                    _xmlWriter.writeBinary(stax2base64v, buf, 0, full);
+                    end -= full;
+                    System.arraycopy(buf, full, buf, 0, end);
+                }
             }
-            if (len == 0) {
-                break;
-            }
+        } finally {
+            _ioContext.releaseBase64Buffer(buf);
         }
-
-        // we still have < 3 bytes in the buffer
-        if(offset > 0) {
-            _xmlWriter.writeBinary(stax2base64v, tmp, 0, offset);
-        }
+        return total;
     }
 
     private byte[] toFullBuffer(byte[] data, int offset, int len)
@@ -1102,6 +1129,22 @@ public class ToXmlGenerator
             offset += count;
         }
         return result;
+    }
+
+    // Variant for "unknown length": read until end-of-stream
+    private byte[] toFullBuffer(InputStream data) throws IOException
+    {
+        final ByteArrayBuilder bb = new ByteArrayBuilder(_ioContext.bufferRecycler());
+        final byte[] tmp = _ioContext.allocBase64Buffer();
+        try {
+            int count;
+            while ((count = data.read(tmp)) >= 0) {
+                bb.write(tmp, 0, count);
+            }
+        } finally {
+            _ioContext.releaseBase64Buffer(tmp);
+        }
+        return bb.getClearAndRelease();
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/BinaryUnknownLengthWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/BinaryUnknownLengthWriteTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 // [dataformat-xml#894]: `JsonGenerator.writeBinary(InputStream, dataLength)` documents a
@@ -34,6 +35,31 @@ public class BinaryUnknownLengthWriteTest extends XmlTestUtil
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
             return super.read(b, off, Math.min(len, 1));
+        }
+    }
+
+    // Stream that fails partway through, to verify buffers are recycled properly
+    static class FailingInputStream extends InputStream
+    {
+        private int _left;
+
+        FailingInputStream(int okBytes) { _left = okBytes; }
+
+        @Override
+        public int read() throws IOException {
+            byte[] b = new byte[1];
+            int count = read(b, 0, 1);
+            return (count < 0) ? -1 : (b[0] & 0xFF);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (_left <= 0) {
+                throw new IOException("Test-induced read failure");
+            }
+            int count = Math.min(len, _left);
+            _left -= count;
+            return count;
         }
     }
 
@@ -168,6 +194,29 @@ public class BinaryUnknownLengthWriteTest extends XmlTestUtil
             gen.writeEndObject();
         }
         assertEquals("<root><bin>" + ENCODED + "</bin></root>", removeSjsxpNamespace(out.toString()));
+    }
+
+    // Failure partway through an unknown-length read must not leave recycled buffers
+    // in a bad state: following writes must still produce correct output
+    @Test
+    public void testFailingStreamReleasesBuffers() throws Exception
+    {
+        for (int i = 0; i < 3; ++i) {
+            StringWriter out = new StringWriter();
+            try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+                gen.setNextName(new QName("root"));
+                gen.writeStartObject();
+                gen.setNextIsAttribute(true);
+                gen.writeFieldName("bin");
+                assertThrows(IOException.class, () -> gen.writeBinary(Base64Variants.MIME,
+                        new FailingInputStream(5000), -1));
+            } catch (IOException e) {
+                // close() may fail due to incomplete output; ignore
+            }
+            // and then verify that buffer recycling still works as expected
+            assertEquals("<root><bin>" + ENCODED + "</bin></root>", _writeElement(
+                    Base64Variants.MIME, DATA, -1));
+        }
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/BinaryUnknownLengthWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/BinaryUnknownLengthWriteTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // [dataformat-xml#894]: `JsonGenerator.writeBinary(InputStream, dataLength)` documents a
 // negative `dataLength` as "length unknown, read to end" (the JSON backend honors it);
@@ -122,21 +123,35 @@ public class BinaryUnknownLengthWriteTest extends XmlTestUtil
     @Test
     public void testLargePayloadUnknownLength() throws Exception
     {
+        _testLargePayload(Base64Variants.MIME_NO_LINEFEEDS, Integer.MAX_VALUE);
+        // and same for a variant that does use linefeeds: chunk boundaries must
+        // align with line boundaries, or lines would end up longer than allowed
+        _testLargePayload(Base64Variants.MIME, 76);
+        _testLargePayload(Base64Variants.PEM, 64);
+    }
+
+    private void _testLargePayload(Base64Variant b64v, int maxLineLength) throws Exception
+    {
         final byte[] big = new byte[7001];
         for (int i = 0; i < big.length; i++) {
             big[i] = (byte) i;
         }
-        // Use variant without line feeds: the Stax2 writer starts a new line counter
-        // for each chunk written, so with MIME only the line break positions would differ
-        final Base64Variant b64v = Base64Variants.MIME_NO_LINEFEEDS;
+        // Streaming output must match what the `byte[]` overload produces
         final String expected = _writeElement(b64v, big);
         final String actual = _writeElement(b64v, big, -1);
         assertEquals(expected, actual);
         assertEquals(expected, _writeElement(b64v, big, big.length));
         assertEquals(_writeAttribute(b64v, big, big.length), _writeAttribute(b64v, big, -1));
 
-        // and finally, make sure it decodes back
+        // and no line may exceed the maximum length variant specifies
         String encoded = actual.substring("<root><bin>".length(), actual.length() - "</bin></root>".length());
+        for (String line : encoded.split("\n", -1)) {
+            if (line.length() > maxLineLength) {
+                fail("Line length "+line.length()+" exceeds max "+maxLineLength+" for "+b64v.getName());
+            }
+        }
+
+        // and finally, make sure it decodes back
         assertArrayEquals(big, b64v.decode(encoded));
     }
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/BinaryUnknownLengthWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/BinaryUnknownLengthWriteTest.java
@@ -1,0 +1,205 @@
+package com.fasterxml.jackson.dataformat.xml.stream;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.Base64Variants;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlTestUtil;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// [dataformat-xml#894]: `JsonGenerator.writeBinary(InputStream, dataLength)` documents a
+// negative `dataLength` as "length unknown, read to end" (the JSON backend honors it);
+// verify the XML backend streams to end instead of failing with a raw runtime exception.
+public class BinaryUnknownLengthWriteTest extends XmlTestUtil
+{
+    // Stream that hands out a single byte per read() call
+    static class ShortReadInputStream extends FilterInputStream
+    {
+        ShortReadInputStream(InputStream in) { super(in); }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return super.read(b, off, Math.min(len, 1));
+        }
+    }
+
+    private final XmlMapper MAPPER = newMapper();
+
+    private final byte[] DATA = utf8Bytes("hello, binary world");
+    // base64 of DATA
+    private final String ENCODED = "aGVsbG8sIGJpbmFyeSB3b3JsZA==";
+
+    @Test
+    public void testElementUnknownLength() throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.writeFieldName("bin");
+            assertEquals(DATA.length,
+                    gen.writeBinary(Base64Variants.MIME, new ByteArrayInputStream(DATA), -1));
+            gen.writeEndObject();
+        }
+        assertEquals("<root><bin>" + ENCODED + "</bin></root>", removeSjsxpNamespace(out.toString()));
+    }
+
+    @Test
+    public void testAttributeUnknownLength() throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.setNextIsAttribute(true);
+            gen.writeFieldName("bin");
+            assertEquals(DATA.length,
+                    gen.writeBinary(Base64Variants.MIME, new ByteArrayInputStream(DATA), -1));
+            gen.writeEndObject();
+        }
+        assertEquals("<root bin=\"" + ENCODED + "\"/>", removeSjsxpNamespace(out.toString()));
+    }
+
+    @Test
+    public void testUnwrappedUnknownLength() throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.writeFieldName("bin");
+            gen.setNextIsUnwrapped(true);
+            assertEquals(DATA.length,
+                    gen.writeBinary(Base64Variants.MIME, new ByteArrayInputStream(DATA), -1));
+            gen.writeEndObject();
+        }
+        assertEquals("<root>" + ENCODED + "</root>", removeSjsxpNamespace(out.toString()));
+    }
+
+    @Test
+    public void testPrettyPrintedUnknownLength() throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.writerWithDefaultPrettyPrinter()
+                .createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.writeFieldName("bin");
+            assertEquals(DATA.length,
+                    gen.writeBinary(Base64Variants.MIME, new ByteArrayInputStream(DATA), -1));
+            gen.writeEndObject();
+        }
+        assertEquals("<root>\n  <bin>" + ENCODED + "</bin>\n</root>\n",
+                removeSjsxpNamespace(out.toString()));
+    }
+
+    // Empty stream should render the same whether length is given as 0 or unknown
+    @Test
+    public void testEmptyStream() throws Exception
+    {
+        final byte[] empty = new byte[0];
+        assertEquals("<root><bin/></root>", _writeElement(Base64Variants.MIME, empty, 0));
+        assertEquals("<root><bin/></root>", _writeElement(Base64Variants.MIME, empty, -1));
+        assertEquals("<root bin=\"\"/>", _writeAttribute(Base64Variants.MIME, empty, 0));
+        assertEquals("<root bin=\"\"/>", _writeAttribute(Base64Variants.MIME, empty, -1));
+    }
+
+    // Payload bigger than the recycled read buffer, and not a multiple of 3, so that
+    // partial triplets have to be carried over between reads
+    @Test
+    public void testLargePayloadUnknownLength() throws Exception
+    {
+        final byte[] big = new byte[7001];
+        for (int i = 0; i < big.length; i++) {
+            big[i] = (byte) i;
+        }
+        // Use variant without line feeds: the Stax2 writer starts a new line counter
+        // for each chunk written, so with MIME only the line break positions would differ
+        final Base64Variant b64v = Base64Variants.MIME_NO_LINEFEEDS;
+        final String expected = _writeElement(b64v, big);
+        final String actual = _writeElement(b64v, big, -1);
+        assertEquals(expected, actual);
+        assertEquals(expected, _writeElement(b64v, big, big.length));
+        assertEquals(_writeAttribute(b64v, big, big.length), _writeAttribute(b64v, big, -1));
+
+        // and finally, make sure it decodes back
+        String encoded = actual.substring("<root><bin>".length(), actual.length() - "</bin></root>".length());
+        assertArrayEquals(big, b64v.decode(encoded));
+    }
+
+    @Test
+    public void testShortReadsUnknownLength() throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.writeFieldName("bin");
+            assertEquals(DATA.length, gen.writeBinary(Base64Variants.MIME,
+                    new ShortReadInputStream(new ByteArrayInputStream(DATA)), -1));
+            gen.writeEndObject();
+        }
+        assertEquals("<root><bin>" + ENCODED + "</bin></root>", removeSjsxpNamespace(out.toString()));
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper methods
+    /**********************************************************************
+     */
+
+    private String _writeElement(Base64Variant b64v, byte[] data) throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.writeFieldName("bin");
+            gen.writeBinary(b64v, data, 0, data.length);
+            gen.writeEndObject();
+        }
+        return removeSjsxpNamespace(out.toString());
+    }
+
+    private String _writeElement(Base64Variant b64v, byte[] data, int dataLength) throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.writeFieldName("bin");
+            assertEquals(data.length,
+                    gen.writeBinary(b64v, new ByteArrayInputStream(data), dataLength));
+            gen.writeEndObject();
+        }
+        return removeSjsxpNamespace(out.toString());
+    }
+
+    private String _writeAttribute(Base64Variant b64v, byte[] data, int dataLength) throws Exception
+    {
+        StringWriter out = new StringWriter();
+        try (ToXmlGenerator gen = (ToXmlGenerator) MAPPER.createGenerator(out)) {
+            gen.setNextName(new QName("root"));
+            gen.writeStartObject();
+            gen.setNextIsAttribute(true);
+            gen.writeFieldName("bin");
+            assertEquals(data.length,
+                    gen.writeBinary(b64v, new ByteArrayInputStream(data), dataLength));
+            gen.writeEndObject();
+        }
+        return removeSjsxpNamespace(out.toString());
+    }
+}


### PR DESCRIPTION
**Raw exception from `writeBinary` when stream length is unknown**

`writeBinary(Base64Variant, InputStream, int)` treats a negative `dataLength` as a real length, but per the `JsonGenerator` contract a negative value means "length unknown, read to the end of stream", and the JSON backend already handles it that way. The attribute path reaches `new byte[dataLength]` and the element path a bounded `read(..., dataLength)`, so the call leaves the generator as a raw `NegativeArraySizeException` / `IndexOutOfBoundsException`.

Fix keeps streaming where the code already streams: `writeStreamAsBinary(...)` now treats `len < 0` as "until EOF" and returns the byte count, reading through the recycled base64 buffer (`_ioContext.allocBase64Buffer()`) instead of 3 bytes per `read()`. Only the attribute and pretty-printer paths, which need a full buffer for the Stax2 API anyway, read the stream to the end (via `ByteArrayBuilder` on the buffer recycler). Non-negative lengths keep prior behavior, and `writeBinary(..., -1)` returns the actual number of bytes written.

Targets `2.x` per review, so it can be merged forward.
