### PR TITLE
modernise code based on Java 17 norms

### DIFF
--- a/src/main/java/tools/jackson/dataformat/xml/DefaultingXmlTypeResolverBuilder.java
+++ b/src/main/java/tools/jackson/dataformat/xml/DefaultingXmlTypeResolverBuilder.java
@@ -63,15 +63,12 @@ public class DefaultingXmlTypeResolverBuilder
             return _customIdResolver;
         }
         // Only override handlers of class, minimal class; name is good as is
-        switch (_idType) {
-        case CLASS:
-            return new XmlTypeResolverBuilder.XmlClassNameIdResolver(baseType,
-                    subtypes, subTypeValidator(ctxt));
-        case MINIMAL_CLASS:
-            return new XmlTypeResolverBuilder.XmlMinimalClassNameIdResolver(baseType,
-                    subtypes, subTypeValidator(ctxt));
-        default:
-        }
-        return super.idResolver(ctxt, baseType, subtypeValidator, subtypes, forSer, forDeser);
+        return switch (_idType) {
+        case CLASS -> new XmlTypeResolverBuilder.XmlClassNameIdResolver(baseType,
+                subtypes, subTypeValidator(ctxt));
+        case MINIMAL_CLASS -> new XmlTypeResolverBuilder.XmlMinimalClassNameIdResolver(baseType,
+                subtypes, subTypeValidator(ctxt));
+        default -> super.idResolver(ctxt, baseType, subtypeValidator, subtypes, forSer, forDeser);
+        };
     }
 }

--- a/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/dataformat/xml/JacksonXmlAnnotationIntrospector.java
@@ -82,7 +82,7 @@ public class JacksonXmlAnnotationIntrospector
             }
             // also: need to ensure we use marker:
             String localName = w.localName();
-            if (localName == null || localName.length() == 0) {
+            if (localName == null || localName.isEmpty()) {
                 return PropertyName.USE_DEFAULT;
             }
             return PropertyName.construct(w.localName(), w.namespace());
@@ -104,7 +104,7 @@ public class JacksonXmlAnnotationIntrospector
             String local = root.localName();
             String ns = root.namespace();
 
-            if (local.length() == 0 && ns.length() == 0) {
+            if (local.isEmpty() && ns.isEmpty()) {
                 return PropertyName.USE_DEFAULT;
             }
             return new PropertyName(local, ns);

--- a/src/main/java/tools/jackson/dataformat/xml/XmlAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlAnnotationIntrospector.java
@@ -35,14 +35,14 @@ public interface XmlAnnotationIntrospector
         public Pair(AnnotationIntrospector p, AnnotationIntrospector s)
         {
             super(p, s);
-            if (p instanceof AnnotationIntrospector.XmlExtensions) {
-                _xmlPrimary = (AnnotationIntrospector.XmlExtensions) p;
+            if (p instanceof AnnotationIntrospector.XmlExtensions xmlExt) {
+                _xmlPrimary = xmlExt;
             } else {
                 _xmlPrimary = null;
             }
 
-            if (s instanceof AnnotationIntrospector.XmlExtensions) {
-                _xmlSecondary = (AnnotationIntrospector.XmlExtensions) s;
+            if (s instanceof AnnotationIntrospector.XmlExtensions xmlExt) {
+                _xmlSecondary = xmlExt;
             } else {
                 _xmlSecondary = null;
             }

--- a/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
@@ -413,11 +413,11 @@ public class XmlFactory
             return null;
         }
         // Ideally should catch earlier, but just in case....
-        if (!(pp instanceof XmlPrettyPrinter)) {
+        if (!(pp instanceof XmlPrettyPrinter xmlPp)) {
             throw new IllegalStateException("Configured PrettyPrinter not of type `XmlPrettyPrinter` but `"
                     +pp.getClass().getName()+"`");
         }
-        return (XmlPrettyPrinter) pp;
+        return xmlPp;
     }
 
     /**

--- a/src/main/java/tools/jackson/dataformat/xml/XmlMapper.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlMapper.java
@@ -281,8 +281,8 @@ public class XmlMapper extends ObjectMapper
 
                 AnnotationIntrospector ai0 = annotationIntrospector();
                 for (AnnotationIntrospector ai : ai0.allIntrospectors()) {
-                    if (ai instanceof JacksonXmlAnnotationIntrospector) {
-                        ((JacksonXmlAnnotationIntrospector) ai).setDefaultUseWrapper(b);
+                    if (ai instanceof JacksonXmlAnnotationIntrospector xmlAi) {
+                        xmlAi.setDefaultUseWrapper(b);
                     }
                 }
             }

--- a/src/main/java/tools/jackson/dataformat/xml/XmlTypeResolverBuilder.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlTypeResolverBuilder.java
@@ -60,16 +60,13 @@ public class XmlTypeResolverBuilder extends StdTypeResolverBuilder
             return _customIdResolver;
         }
         // Only override handlers of class, minimal class; name is good as is
-        switch (_idType) {
-        case CLASS:
-            return new XmlClassNameIdResolver(baseType, subtypes,
-                    subTypeValidator(ctxt));
-        case MINIMAL_CLASS:
-            return new XmlMinimalClassNameIdResolver(baseType, subtypes,
-                    subTypeValidator(ctxt));
-        default:
-        }
-        return super.idResolver(ctxt, baseType, subtypeValidator, subtypes, forSer, forDeser);
+        return switch (_idType) {
+        case CLASS -> new XmlClassNameIdResolver(baseType, subtypes,
+                subTypeValidator(ctxt));
+        case MINIMAL_CLASS -> new XmlMinimalClassNameIdResolver(baseType, subtypes,
+                subTypeValidator(ctxt));
+        default -> super.idResolver(ctxt, baseType, subtypeValidator, subtypes, forSer, forDeser);
+        };
     }
 
     /*

--- a/src/main/java/tools/jackson/dataformat/xml/deser/ElementWrapper.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/ElementWrapper.java
@@ -1,5 +1,7 @@
 package tools.jackson.dataformat.xml.deser;
 
+import java.util.Objects;
+
 /**
  * Helper class needed to keep track of virtual wrapper elements
  * added in the logical XML token stream.
@@ -27,7 +29,7 @@ class ElementWrapper
     {
         _parent = parent;
         _wrapperName = wrapperLocalName;
-        _wrapperNamespace = (wrapperNamespace == null) ? "" : wrapperNamespace;
+        _wrapperNamespace = Objects.requireNonNullElse(wrapperNamespace, "");
     }
 
     /**

--- a/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -245,17 +245,17 @@ public class FromXmlParser
             _xmlTokens.markAsStreamEnd();
         } else {
             switch (firstToken) {
-            case XmlTokenStream.XML_START_ELEMENT:
-            // Removed from 2.14:
-            // case XmlTokenStream.XML_DELAYED_START_ELEMENT:
+            case XmlTokenStream.XML_START_ELEMENT -> {
+                // Removed from 2.14:
+                // case XmlTokenStream.XML_DELAYED_START_ELEMENT:
                 // [dataformat-xml#484]: in wrap mode, suppress queuing the
                 // (inner) START_OBJECT here; the wrap state machine queues it
                 // explicitly after delivering outer START + PROPERTY_NAME.
                 if (!wrapRoot) {
                     _nextToken = JsonToken.START_OBJECT;
                 }
-                break;
-            case XmlTokenStream.XML_ROOT_TEXT:
+            }
+            case XmlTokenStream.XML_ROOT_TEXT -> {
                 _currText = _xmlTokens.getText();
                 // [dataformat-xml#435]: may get `null` from empty element...
                 // It's complicated.
@@ -264,9 +264,8 @@ public class FromXmlParser
                 } else {
                     _nextToken = JsonToken.VALUE_STRING;
                 }
-                break;
-            default:
-                _reportError("Internal problem: invalid starting state (%s)", _xmlTokens._currentStateDesc());
+            }
+            default -> _reportError("Internal problem: invalid starting state (%s)", _xmlTokens._currentStateDesc());
             }
         }
         // [dataformat-xml#484]: activate wrap state machine if feature enabled
@@ -607,17 +606,10 @@ public class FromXmlParser
             _nextToken = null;
 
             switch (t) {
-            case START_OBJECT:
-                _createChildObjectContext();
-                break;
-            case START_ARRAY:
-                _createChildArrayContext();
-                break;
-            case END_OBJECT:
-            case END_ARRAY:
-                _streamReadContext = _streamReadContext.getParent();
-                break;
-            case PROPERTY_NAME:
+            case START_OBJECT -> _createChildObjectContext();
+            case START_ARRAY -> _createChildArrayContext();
+            case END_OBJECT, END_ARRAY -> _streamReadContext = _streamReadContext.getParent();
+            case PROPERTY_NAME -> {
                 // 29-Mar-2021, tatu: [dataformat-xml#442]: special case of leading
                 //    mixed text added
                 if (_nextIsLeadingMixed) {
@@ -627,8 +619,8 @@ public class FromXmlParser
                 } else {
                     _streamReadContext.setCurrentName(_xmlTokens.getLocalName());
                 }
-                break;
-            default: // VALUE_STRING, VALUE_NULL
+            }
+            default -> { // VALUE_STRING, VALUE_NULL
                 // 13-May-2020, tatu: [dataformat-xml#397]: advance `index` anyway; not
                 //    used for Object contexts, updated automatically by "createChildXxxContext"
                 _streamReadContext.valueStarted();
@@ -636,6 +628,7 @@ public class FromXmlParser
                 if (_rootWrapStage == WRAP_OPEN_SCALAR) {
                     _rootWrapStage = WRAP_PENDING_OUTER_END;
                 }
+            }
             }
             return t;
         }
@@ -771,9 +764,9 @@ public class FromXmlParser
                         return _updateToken(JsonToken.VALUE_STRING);
                     }
                     if (token != XmlTokenStream.XML_START_ELEMENT) {
-                        throw _constructReadException(String.format(
-"Internal error: Expected END_ELEMENT (%d) or START_ELEMENT (%d), got event of type %d",
-XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
+                        throw _constructReadException(
+"Internal error: Expected END_ELEMENT (%d) or START_ELEMENT (%d), got event of type %d"
+                                .formatted(XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
                     }
                     // fall-through, except must create new context AND push back
                     // START_ELEMENT we just saw:
@@ -848,12 +841,13 @@ _currText);
      */
     private JsonToken _nextRootWrapToken()
     {
-        switch (_rootWrapStage) {
-        case WRAP_PENDING_OUTER_START:
+        return switch (_rootWrapStage) {
+        case WRAP_PENDING_OUTER_START -> {
             _rootWrapStage = WRAP_PENDING_NAME;
             _streamReadContext = _streamReadContext.createChildObjectContext(-1, -1);
-            return _updateToken(JsonToken.START_OBJECT);
-        case WRAP_PENDING_NAME:
+            yield _updateToken(JsonToken.START_OBJECT);
+        }
+        case WRAP_PENDING_NAME -> {
             // Object body case: queue inner START_OBJECT for normal flow to consume.
             // Scalar/null body case: _nextToken already holds the value.
             if (_nextToken == null) {
@@ -863,15 +857,18 @@ _currText);
                 _rootWrapStage = WRAP_OPEN_SCALAR;
             }
             _streamReadContext.setCurrentName(_xmlTokens.getRootName().getLocalPart());
-            return _updateToken(JsonToken.PROPERTY_NAME);
-        case WRAP_PENDING_OUTER_END:
+            yield _updateToken(JsonToken.PROPERTY_NAME);
+        }
+        case WRAP_PENDING_OUTER_END -> {
             _rootWrapStage = WRAP_INACTIVE;
             _streamReadContext = _streamReadContext.getParent();
-            return _updateToken(JsonToken.END_OBJECT);
-        default:
-            // WRAP_OPEN_OBJECT / WRAP_OPEN_SCALAR — caller should fall through.
-            return null;
+            yield _updateToken(JsonToken.END_OBJECT);
         }
+        default -> {
+            // WRAP_OPEN_OBJECT / WRAP_OPEN_SCALAR — caller should fall through.
+            yield null;
+        }
+        };
     }
 
     /*
@@ -1008,21 +1005,11 @@ _currText);
     private void _updateState(JsonToken t)
     {
         switch (t) {
-        case START_OBJECT:
-            _createChildObjectContext();
-            break;
-        case START_ARRAY:
-            _createChildArrayContext();
-            break;
-        case END_OBJECT:
-        case END_ARRAY:
-            _streamReadContext = _streamReadContext.getParent();
-            break;
-        case PROPERTY_NAME:
-            _streamReadContext.setCurrentName(_xmlTokens.getLocalName());
-            break;
-        default:
-            _internalErrorUnknownToken(t);
+        case START_OBJECT -> _createChildObjectContext();
+        case START_ARRAY -> _createChildArrayContext();
+        case END_OBJECT, END_ARRAY -> _streamReadContext = _streamReadContext.getParent();
+        case PROPERTY_NAME -> _streamReadContext.setCurrentName(_xmlTokens.getLocalName());
+        default -> _internalErrorUnknownToken(t);
         }
     }
 
@@ -1053,14 +1040,11 @@ _currText);
         if (_currToken == null) {
             return null;
         }
-        switch (_currToken) {
-        case PROPERTY_NAME:
-            return currentName();
-        case VALUE_STRING:
-            return _currText;
-        default:
-            return _currToken.asString();
-        }
+        return switch (_currToken) {
+        case PROPERTY_NAME -> currentName();
+        case VALUE_STRING -> _currText;
+        default -> _currToken.asString();
+        };
     }
 
     @Override
@@ -1403,9 +1387,9 @@ _currText);
     {
         if (!_streamReadContext.inRoot()) {
             String marker = _streamReadContext.inArray() ? "Array" : "Object";
-            _reportInvalidEOF(String.format(
-                    ": expected close marker for %s (start marker at %s)",
-                    marker,
+            _reportInvalidEOF(
+                    ": expected close marker for %s (start marker at %s)"
+                            .formatted(marker,
                     _streamReadContext.startLocation(_ioContext.contentReference())),
                     null);
         }

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlBeanDeserializerModifier.java
@@ -65,7 +65,7 @@ public class XmlBeanDeserializerModifier
             
             if (wrapperName != null && wrapperName != PropertyName.NO_NAME) {
                 String localName = wrapperName.getSimpleName();
-                if ((localName != null && localName.length() > 0)
+                if ((localName != null && !localName.isEmpty())
                         && !localName.equals(prop.getName())) {
                     // make copy-on-write as necessary
                     if (changed == 0) {

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlReadContext.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlReadContext.java
@@ -202,7 +202,7 @@ public final class XmlReadContext
     {
         if (dd.isDup(name)) {
             Object src = dd.getSource();
-            throw new StreamReadException(((src instanceof JsonParser) ? ((JsonParser) src) : null),
+            throw new StreamReadException(((src instanceof JsonParser jsonParser) ? jsonParser : null),
                     "Duplicate Object property \""+name+"\"");
         }
     }
@@ -234,15 +234,13 @@ public final class XmlReadContext
     {
         StringBuilder sb = new StringBuilder(64);
         switch (_type) {
-        case TYPE_ROOT:
-            sb.append("/");
-            break;
-        case TYPE_ARRAY:
+        case TYPE_ROOT -> sb.append("/");
+        case TYPE_ARRAY -> {
             sb.append('[');
             sb.append(getCurrentIndex());
             sb.append(']');
-            break;
-        case TYPE_OBJECT:
+        }
+        case TYPE_OBJECT -> {
             sb.append('{');
             if (_currentName != null) {
                 sb.append('"');
@@ -252,7 +250,7 @@ public final class XmlReadContext
                 sb.append('?');
             }
             sb.append('}');
-            break;
+        }
         }
         return sb.toString();
     }

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlTokenBuffer.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlTokenBuffer.java
@@ -267,15 +267,15 @@ public class XmlTokenBuffer extends TokenBuffer
         }
 
         private JsonToken _nextTokenWrapping() throws JacksonException {
-            switch (_wrapState) {
-            case STATE_EMIT_START_ARRAY:
+            return switch (_wrapState) {
+            case STATE_EMIT_START_ARRAY -> {
                 _wrapState = STATE_WRAPPING;
                 _wrapDepth = 0;
                 _virtualToken = JsonToken.START_ARRAY;
                 _virtualName = null;
-                return JsonToken.START_ARRAY;
-
-            case STATE_EMIT_PENDING:
+                yield JsonToken.START_ARRAY;
+            }
+            case STATE_EMIT_PENDING -> {
                 JsonToken pt = _pendingToken;
                 String pn = _pendingName;
                 _pendingToken = null;
@@ -289,14 +289,11 @@ public class XmlTokenBuffer extends TokenBuffer
                 } else {
                     _wrapState = STATE_NORMAL;
                 }
-                return pt;
-
-            case STATE_WRAPPING:
-                return _nextWrapping();
-
-            default: // STATE_NORMAL
-                return _nextNormal();
+                yield pt;
             }
+            case STATE_WRAPPING -> _nextWrapping();
+            default -> _nextNormal(); // STATE_NORMAL
+            };
         }
 
         private JsonToken _nextNormal() throws JacksonException {

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -1,6 +1,7 @@
 package tools.jackson.dataformat.xml.deser;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
@@ -220,7 +221,7 @@ public class XmlTokenStream
         String rootPrefix = _xmlReader.getPrefix();
         _decodeElementName(_xmlReader.getNamespaceURI(), _xmlReader.getLocalName());
         _rootName = new QName(_namespaceURI, _localName,
-                (rootPrefix == null) ? "" : rootPrefix);
+                Objects.requireNonNullElse(rootPrefix, ""));
 
         // 02-Jul-2020, tatu: Two choices: if child elements OR attributes, expose
         //    as Object value; otherwise expose as Text
@@ -334,9 +335,9 @@ public class XmlTokenStream
     {
         int type = next();
         if (type != XML_END_ELEMENT) {
-            throw new IOException(String.format(
-                    "Internal error: Expected END_ELEMENT, got event of type %s",
-                    _stateDesc(type)));
+            throw new IOException(
+                    "Internal error: Expected END_ELEMENT, got event of type %s"
+                    .formatted(_stateDesc(type)));
         }
     }
 
@@ -455,26 +456,22 @@ public class XmlTokenStream
     {
 //System.out.println(" XmlTokenStream.skipAttributes(), state: "+_currentStateDesc());
         switch (_currentState) {
-        case XML_ATTRIBUTE_NAME:
+        case XML_ATTRIBUTE_NAME -> {
             _attributeCount = 0;
             _currentState = XML_START_ELEMENT;
-            break;
-        case XML_START_ELEMENT:
+        }
+        case XML_START_ELEMENT, XML_TEXT -> {
             // 06-Jan-2012, tatu: As per [#47] it looks like we should NOT do anything
             //   in this particular case, because it occurs when original element had
             //   no attributes and we now point to the first child element.
 //              _attributeCount = 0;
-            break;
-        case XML_TEXT:
-            break; // nothing to do... is it even legal?
-
+        }
             /*
         case XML_DELAYED_START_ELEMENT:
             // 03-Jul-2020, tatu: and here nothing to do either... ?
             break;
             */
-        default:
-            throw new IllegalStateException(
+        default -> throw new IllegalStateException(
 "Current state not XML_START_ELEMENT or XML_ATTRIBUTE_NAME but "+_currentStateDesc());
         }
     }
@@ -712,8 +709,8 @@ public class XmlTokenStream
             return r.getText();
         } catch (RuntimeException e) {
             Throwable cause = e.getCause();
-            if (cause instanceof XMLStreamException) {
-                throw (XMLStreamException) cause;
+            if (cause instanceof XMLStreamException xse) {
+                throw xse;
             }
             throw e;
         }
@@ -855,8 +852,8 @@ public class XmlTokenStream
             _nameProcessor.decodeName(name);
         } catch (IllegalArgumentException e) {
             throw new StreamReadException(null,
-                    String.format("Failed to decode XML name \"%s\": %s",
-                            name.localPart, e.getMessage()),
+                    "Failed to decode XML name \"%s\": %s"
+                            .formatted(name.localPart, e.getMessage()),
                     getCurrentLocation(), e);
         }
     }
@@ -961,25 +958,18 @@ public class XmlTokenStream
     }
 
     protected String _stateDesc(int state) {
-        switch (state) {
-        case XML_START_ELEMENT:
-            return "XML_START_ELEMENT";
-        case XML_END_ELEMENT:
-            return "XML_END_ELEMENT";
-        case XML_ATTRIBUTE_NAME:
-            return "XML_ATTRIBUTE_NAME";
-        case XML_ATTRIBUTE_VALUE:
-            return "XML_ATTRIBUTE_VALUE";
-        case XML_TEXT:
-            return "XML_TEXT";
+        return switch (state) {
+        case XML_START_ELEMENT -> "XML_START_ELEMENT";
+        case XML_END_ELEMENT -> "XML_END_ELEMENT";
+        case XML_ATTRIBUTE_NAME -> "XML_ATTRIBUTE_NAME";
+        case XML_ATTRIBUTE_VALUE -> "XML_ATTRIBUTE_VALUE";
+        case XML_TEXT -> "XML_TEXT";
         // case XML_DELAYED_START_ELEMENT:
         //    return "XML_START_ELEMENT_DELAYED";
-        case XML_ROOT_TEXT:
-            return "XML_ROOT_TEXT";
-        case XML_END:
-            return "XML_END";
-        }
-        return "N/A ("+_currentState+")";
+        case XML_ROOT_TEXT -> "XML_ROOT_TEXT";
+        case XML_END -> "XML_END";
+        default -> "N/A ("+_currentState+")";
+        };
     }
 
     // for DEBUGGING

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlValueInstantiators.java
@@ -155,7 +155,7 @@ public class XmlValueInstantiators
                 PropertyName wrapperName = propDef.getWrapperName();
                 if (wrapperName != null && wrapperName != PropertyName.NO_NAME) {
                     String localName = wrapperName.getSimpleName();
-                    if (localName != null && localName.length() > 0
+                    if (localName != null && !localName.isEmpty()
                             && !localName.equals(origName)) {
                         renamed = localName;
                     }

--- a/src/main/java/tools/jackson/dataformat/xml/ser/XmlBeanPropertyWriter.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/XmlBeanPropertyWriter.java
@@ -177,7 +177,7 @@ public class XmlBeanPropertyWriter
             }
         }
 
-        final ToXmlGenerator xmlGen = (g instanceof ToXmlGenerator) ? (ToXmlGenerator) g : null;
+        final ToXmlGenerator xmlGen = (g instanceof ToXmlGenerator x) ? x : null;
         // Ok then; addition we want to do is to add wrapper element, and that's what happens here
         // 19-Aug-2013, tatu: ... except for those nasty 'convertValue()' calls...
         if (xmlGen != null) {

--- a/src/main/java/tools/jackson/dataformat/xml/ser/XmlBeanSerializerBase.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/XmlBeanSerializerBase.java
@@ -167,11 +167,10 @@ public abstract class XmlBeanSerializerBase extends BeanSerializerBase
         throws JacksonException
     {
         // 19-Aug-2013, tatu: During 'convertValue()', need to skip
-        if (!(gen0 instanceof ToXmlGenerator)) {
+        if (!(gen0 instanceof ToXmlGenerator xgen)) {
             super._serializeProperties(bean, gen0, ctxt);
             return;
         }
-        final ToXmlGenerator xgen = (ToXmlGenerator) gen0;
         final BeanPropertyWriter[] props;
         if (_filteredProps != null && ctxt.getActiveView() != null) {
             props = _filteredProps;
@@ -233,12 +232,10 @@ public abstract class XmlBeanSerializerBase extends BeanSerializerBase
         throws JacksonException
     {
         // 19-Aug-2013, tatu: During 'convertValue()', need to skip
-        if (!(gen0 instanceof ToXmlGenerator)) {
+        if (!(gen0 instanceof ToXmlGenerator xgen)) {
             super._serializePropertiesFiltered(bean, gen0, ctxt, filterId);
             return;
         }
-        
-        final ToXmlGenerator xgen = (ToXmlGenerator) gen0;
         
         final BeanPropertyWriter[] props;
         if (_filteredProps != null && ctxt.getActiveView() != null) {

--- a/src/main/java/tools/jackson/dataformat/xml/ser/XmlBeanSerializerModifier.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/XmlBeanSerializerModifier.java
@@ -90,7 +90,7 @@ public class XmlBeanSerializerModifier
             }
             // no local name? Just double the wrapped name for wrapper
             String localName = wrapperName.getSimpleName();
-            if (localName == null || localName.length() == 0) {
+            if (localName == null || localName.isEmpty()) {
                 wrapperName = wrappedName;
             }
             // [dataformat-xml#8]: for Object-typed properties, use dynamic wrapping
@@ -108,9 +108,9 @@ public class XmlBeanSerializerModifier
         // First things first: we can only handle real BeanSerializers; question
         // is, what to do if it's not one: throw exception or bail out?
         // For now let's do latter.
-        if (!(serializer instanceof BeanSerializerBase)) {
+        if (!(serializer instanceof BeanSerializerBase base)) {
             return serializer;
         }
-        return new XmlBeanSerializer((BeanSerializerBase) serializer);
+        return new XmlBeanSerializer(base);
     }
 }

--- a/src/main/java/tools/jackson/dataformat/xml/ser/XmlSerializationContext.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/XmlSerializationContext.java
@@ -211,8 +211,8 @@ public class XmlSerializationContext extends SerializationContextExt
         if (rootName == null) {
             rootName = XmlRootNameLookup.ROOT_NAME_FOR_NULL;
         }
-        if (gen instanceof ToXmlGenerator) {
-            _initWithRootName((ToXmlGenerator) gen, rootName);
+        if (gen instanceof ToXmlGenerator xgen) {
+            _initWithRootName(xgen, rootName);
         }
         super.serializeValue(gen, null);
     }
@@ -239,7 +239,7 @@ public class XmlSerializationContext extends SerializationContextExt
         // [dataformat-xml#26] If we just try writing root element with namespace,
         // we will get an explicit prefix. But we'd rather use the default
         // namespace, so let's try to force that.
-        if (ns != null && ns.length() > 0) {
+        if (ns != null && !ns.isEmpty()) {
             try {
                 xgen.getStaxWriter().setDefaultNamespace(ns);
             } catch (XMLStreamException e) {
@@ -264,8 +264,8 @@ public class XmlSerializationContext extends SerializationContextExt
     protected boolean _shouldUnwrapObjectNode(ToXmlGenerator xgen, Object value)
     {
         return xgen.isEnabled(XmlWriteFeature.UNWRAP_ROOT_OBJECT_NODE)
-                && (value instanceof ObjectNode)
-                && (((ObjectNode) value).size() == 1);
+                && (value instanceof ObjectNode objectNode)
+                && (objectNode.size() == 1);
     }
 
     protected void _serializeUnwrappedObjectNode(ToXmlGenerator xgen, Object value,
@@ -288,7 +288,7 @@ public class XmlSerializationContext extends SerializationContextExt
 
     protected ToXmlGenerator _asXmlGenerator(JsonGenerator gen)
     {
-        if (!(gen instanceof ToXmlGenerator)) {
+        if (!(gen instanceof ToXmlGenerator xgen)) {
             // [dataformat-xml#71]: We sometimes get TokenBuffer, which is fine
             if (gen instanceof TokenBuffer) {
                 return null;
@@ -298,18 +298,18 @@ public class XmlSerializationContext extends SerializationContextExt
                     "XmlMapper does not work with generators of type other than `ToXmlGenerator`; got: `"
                             +gen.getClass().getName()+"`");
         }
-        return (ToXmlGenerator) gen;
+        return xgen;
     }    
 
     protected JacksonException _wrapAsJacksonE(JsonGenerator g, Exception e)
     {
-        if (e instanceof IOException) {
-            return JacksonIOException.construct((IOException) e);
+        if (e instanceof IOException ioException) {
+            return JacksonIOException.construct(ioException);
         }
         // 17-Jan-2021, tatu: Should we do something else here? Presumably
         //    this exception has map set up
-        if (e instanceof DatabindException) {
-            throw (DatabindException) e;
+        if (e instanceof DatabindException databindException) {
+            throw databindException;
         }
         String msg = e.getMessage();
         if (msg == null) {

--- a/src/main/java/tools/jackson/dataformat/xml/util/AnnotationUtil.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/AnnotationUtil.java
@@ -21,8 +21,8 @@ public class AnnotationUtil
     {
         if (prop != null) {
             for (AnnotationIntrospector intr : ai.allIntrospectors()) {
-                if (intr instanceof AnnotationIntrospector.XmlExtensions) {
-                    String ns = ((AnnotationIntrospector.XmlExtensions) intr).findNamespace(config, prop);
+                if (intr instanceof AnnotationIntrospector.XmlExtensions xmlExt) {
+                    String ns = xmlExt.findNamespace(config, prop);
                     if (ns != null) {
                         return ns;
                     }
@@ -38,8 +38,8 @@ public class AnnotationUtil
     {
         if (prop != null) {
             for (AnnotationIntrospector intr : ai.allIntrospectors()) {
-                if (intr instanceof AnnotationIntrospector.XmlExtensions) {
-                    Boolean b = ((AnnotationIntrospector.XmlExtensions) intr).isOutputAsAttribute(config, prop);
+                if (intr instanceof AnnotationIntrospector.XmlExtensions xmlExt) {
+                    Boolean b = xmlExt.isOutputAsAttribute(config, prop);
                     if (b != null) {
                         return b;
                     }
@@ -55,8 +55,8 @@ public class AnnotationUtil
     {
         if (prop != null) {
             for (AnnotationIntrospector intr : ai.allIntrospectors()) {
-                if (intr instanceof AnnotationIntrospector.XmlExtensions) {
-                    Boolean b = ((AnnotationIntrospector.XmlExtensions) intr).isOutputAsText(config, prop);
+                if (intr instanceof AnnotationIntrospector.XmlExtensions xmlExt) {
+                    Boolean b = xmlExt.isOutputAsText(config, prop);
                     if (b != null) {
                         return b;
                     }
@@ -72,8 +72,8 @@ public class AnnotationUtil
     {
         if (prop != null) {
             for (AnnotationIntrospector intr : ai.allIntrospectors()) {
-                if (intr instanceof AnnotationIntrospector.XmlExtensions) {
-                    Boolean b = ((AnnotationIntrospector.XmlExtensions) intr).isOutputAsCData(config, prop);
+                if (intr instanceof AnnotationIntrospector.XmlExtensions xmlExt) {
+                    Boolean b = xmlExt.isOutputAsCData(config, prop);
                     if (b != null) {
                         return b;
                     }
@@ -93,8 +93,8 @@ public class AnnotationUtil
     {
         if (prop != null) {
             for (AnnotationIntrospector intr : ai.allIntrospectors()) {
-                if (intr instanceof AnnotationIntrospector.XmlExtensions) {
-                    PropertyName name = ((AnnotationIntrospector.XmlExtensions) intr).findXmlPropertyInnerName(config, prop);
+                if (intr instanceof AnnotationIntrospector.XmlExtensions xmlExt) {
+                    PropertyName name = xmlExt.findXmlPropertyInnerName(config, prop);
                     if (name != null) {
                         return name;
                     }

--- a/src/main/java/tools/jackson/dataformat/xml/util/ArgUtil.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/ArgUtil.java
@@ -1,5 +1,7 @@
 package tools.jackson.dataformat.xml.util;
 
+import java.util.Objects;
+
 public abstract class ArgUtil
 {
     public static String emptyToNull(String str) {
@@ -7,7 +9,7 @@ public abstract class ArgUtil
     }
 
     public static String nullToEmpty(String str) {
-        return (str == null) ? "" : str;
+        return Objects.requireNonNullElse(str, "");
     }
 
     public static String nonEmptyNonNull(String prop, String str) {

--- a/src/main/java/tools/jackson/dataformat/xml/util/Stax2JacksonReaderAdapter.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/Stax2JacksonReaderAdapter.java
@@ -26,8 +26,8 @@ public class Stax2JacksonReaderAdapter
 
     public static XMLStreamReader2 wrapIfNecessary(XMLStreamReader sr)
     {
-        if (sr instanceof XMLStreamReader2) {
-            return (XMLStreamReader2) sr;
+        if (sr instanceof XMLStreamReader2 xmlStreamReader2) {
+            return xmlStreamReader2;
         }
         return new Stax2JacksonReaderAdapter(sr);
     }

--- a/src/main/java/tools/jackson/dataformat/xml/util/StaxUtil.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/StaxUtil.java
@@ -31,8 +31,8 @@ public class StaxUtil
         while (t.getCause() != null) {
             t = t.getCause();
         }
-        if (t instanceof Error) throw (Error) t;
-        if (t instanceof RuntimeException) throw (RuntimeException) t;
+        if (t instanceof Error e) throw e;
+        if (t instanceof RuntimeException re) throw re;
         return t;
     }
 

--- a/src/main/java/tools/jackson/dataformat/xml/util/XmlInfo.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/XmlInfo.java
@@ -13,10 +13,10 @@ public class XmlInfo
     
     public XmlInfo(Boolean isAttribute, String ns, Boolean isText, Boolean isCData)
     {
-        _isAttribute = (isAttribute == null) ? false : isAttribute.booleanValue();
+        _isAttribute = Boolean.TRUE.equals(isAttribute);
         _namespace = (ns == null) ? "" : ns;
-        _isText = (isText == null) ? false : isText.booleanValue();
-        _isCData = (isCData == null) ? false : isCData.booleanValue();
+        _isText = Boolean.TRUE.equals(isText);
+        _isCData = Boolean.TRUE.equals(isCData);
     }
 
     public String getNamespace() { return _namespace; }

--- a/src/main/java/tools/jackson/dataformat/xml/util/XmlRootNameLookup.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/XmlRootNameLookup.java
@@ -73,7 +73,7 @@ public class XmlRootNameLookup
             ns = root.getNamespace();
         }
         // No answer so far? Let's just default to using simple class name
-        if (localName == null || localName.length() == 0) {
+        if (localName == null || localName.isEmpty()) {
             // Should we strip out enclosing class tho? For now, nope:
             // one caveat: array simple names end with "[]"; also, "$" needs replacing
             localName = StaxUtil.sanitizeXmlTypeName(rootType.getSimpleName());
@@ -98,8 +98,8 @@ public class XmlRootNameLookup
     {
         final MapperConfig<?> config = ctxt.getConfig();
         for (AnnotationIntrospector intr : ai.allIntrospectors()) {
-            if (intr instanceof AnnotationIntrospector.XmlExtensions) {
-                String ns = ((AnnotationIntrospector.XmlExtensions) intr).findNamespace(config, ann);
+            if (intr instanceof AnnotationIntrospector.XmlExtensions xmlExtensions) {
+                String ns = xmlExtensions.findNamespace(config, ann);
                 if (ns != null) {
                     return ns;
                 }


### PR DESCRIPTION
Pattern matching instanceof — 22 edits in 13 files
- Eliminated verbose instanceof + cast patterns across XmlAnnotationIntrospector, XmlFactory, XmlMapper, StaxUtil, AnnotationUtil, Stax2JacksonReaderAdapter, XmlRootNameLookup, XmlReadContext, XmlTokenStream, XmlBeanSerializerModifier, XmlBeanSerializerBase, XmlBeanPropertyWriter, XmlSerializationContext

Switch expressions/arrow notation — 11 conversions in 6 files
- FromXmlParser: 5 switches converted (arrow notation + switch expressions with yield)
- XmlTokenStream: 2 switches converted (switch expression + arrow notation with merged cases)
- XmlTokenBuffer: 1 switch expression with yield blocks
- XmlReadContext: 1 arrow notation conversion
- XmlTypeResolverBuilder + DefaultingXmlTypeResolverBuilder: 2 switch expressions folding empty defaults

Minor idioms — 16 edits in 10 files
- .length() == 0 → .isEmpty(): 6 locations
- String.format() → .formatted(): 4 locations
- Boolean null-guards → Boolean.TRUE.equals(): 3 locations
- Null ternaries → Objects.requireNonNullElse(): 3 locations

Verification: 609 tests pass, 0 failures.