### PR TITLE
Fix #892: ignore whitespace-only unnamed XML text as unknown property

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -158,6 +158,14 @@ Christian Beikov (@beikov)
    with `@JsonIgnore`-annotated getter
   (3.2.2)
 
+Lavender Shannon (@retrodaredevil)
+ * Reported #892: Whitespace-only element body treated as unknown property `""`
+  (3.3.0)
+
+@arimu1
+ * Fixed #892: Ignore whitespace-only unnamed XML text as unknown property
+  (3.3.0)
+
 @Sahana2524
  * Contributed #891: Enforce `StreamReadConstraints.maxNestingDepth` in
    `FromXmlParser`

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,6 +7,9 @@ Version: 3.x (for earlier see VERSION-2.x)
 
 3.3.0 (not yet released)
 
+#892: Whitespace-only element body treated as unknown property `""`
+ (reported by @retrodaredevil)
+ (fix by @arimu1)
 #873: Fix handling of `@JsonApplyView`
  (fix by @cowtowncoder, w/ Claude code)
 #878: Re-apply entity/DTD hardening after JDK deserialization of `XmlFactory`

--- a/src/main/java/tools/jackson/dataformat/xml/deser/XmlDeserializationContext.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/XmlDeserializationContext.java
@@ -49,6 +49,25 @@ public class XmlDeserializationContext
     /**********************************************************************
      */
 
+    /**
+     * [dataformat-xml#892]: Pretty-printed XML with attribute-only beans/records
+     * exposes whitespace-only character data as the unnamed text property
+     * ({@code ""} by default). Skip that synthetic property when it is not
+     * mapped ({@code @JacksonXmlText}); mapped text still binds as usual.
+     */
+    @Override
+    public boolean handleUnknownProperty(JsonParser p, ValueDeserializer<?> deser,
+            Object instanceOrClass, String propName)
+        throws JacksonException
+    {
+        if (_xmlTextElementName.equals(propName)
+                && _isIgnorableWhitespaceXmlText(p)) {
+            p.skipChildren();
+            return true;
+        }
+        return super.handleUnknownProperty(p, deser, instanceOrClass, propName);
+    }
+
     @Override
     public Object readRootValue(JsonParser p, JavaType valueType,
             ValueDeserializer<Object> deser, Object valueToUpdate)
@@ -119,6 +138,13 @@ public class XmlDeserializationContext
     /* Internal helper methods
     /**********************************************************************
      */
+
+    private static boolean _isIgnorableWhitespaceXmlText(JsonParser p)
+        throws JacksonException
+    {
+        return (p.currentToken() == JsonToken.VALUE_STRING)
+                && XmlTokenStream._allWs(p.getString());
+    }
 
     /**
      * Helper method for [dataformat-xml#247]: verify that the root element name

--- a/src/test/java/tools/jackson/dataformat/xml/deser/WhitespaceOnlyUnknownProp892Test.java
+++ b/src/test/java/tools/jackson/dataformat/xml/deser/WhitespaceOnlyUnknownProp892Test.java
@@ -1,0 +1,65 @@
+package tools.jackson.dataformat.xml.deser;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// [dataformat-xml#892]: whitespace-only element body on an attribute-only type
+// must not be treated as unknown property ""
+public class WhitespaceOnlyUnknownProp892Test extends XmlTestUtil
+{
+    record Response(
+            @JsonProperty("Item") Item item
+    ) {
+    }
+
+    record Item(String name) {
+    }
+
+    static class ItemPojo {
+        public String name;
+    }
+
+    private final XmlMapper MAPPER = mapperBuilder()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
+
+    private static final String ISSUE_XML = """
+            <Response>
+            \t<Item name="example">
+            \t</Item>
+            </Response>
+            """;
+
+    @Test
+    public void testRecordWhitespaceOnlyBody892() throws Exception
+    {
+        Response response = MAPPER.readValue(ISSUE_XML, Response.class);
+        assertEquals(new Item("example"), response.item());
+    }
+
+    @Test
+    public void testPojoWhitespaceOnlyBody892() throws Exception
+    {
+        ItemPojo item = MAPPER.readValue("<Item name=\"example\">\n\t</Item>", ItemPojo.class);
+        assertEquals("example", item.name);
+    }
+
+    @Test
+    public void testNonWhitespaceTextStillUnknown892() throws Exception
+    {
+        try {
+            MAPPER.readValue("<Item name=\"example\">secret</Item>", ItemPojo.class);
+            fail("Should not pass");
+        } catch (UnrecognizedPropertyException e) {
+            verifyException(e, "Unrecognized property \"\"");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #892

## Root cause

Pretty-printed XML with attribute-only beans/records exposes whitespace-only element body as the unnamed XML text property (`""` by default). With `FAIL_ON_UNKNOWN_PROPERTIES` that synthetic property is treated as unknown, even though it is only formatting whitespace between the start and end tags.

This is the same unnamed-text channel used for `@JacksonXmlText` ([dataformat-xml#565]); it should fail only when the text is actual unknown content.

## Change

- Override `XmlDeserializationContext.handleUnknownProperty` to skip the unnamed text property when its value is whitespace-only.
- Mapped `@JacksonXmlText` is unchanged (the property is known).
- Non-whitespace unnamed text still fails when the property is unknown.

## Test plan

- [x] `WhitespaceOnlyUnknownProp892Test` — issue XML on records + POJO; non-whitespace body still `UnrecognizedPropertyException`
- [x] Neighbors: `XmlTextWhitespace565Test`, `EmptyBeanDeser318Test`, `XmlEmptyRecordDeser508Test`, `XmlRecordDeser735Test`, `XmlClassDeser735Test`, `TextValueTest`, `XmlTextTest`
- [x] Full `mvn test` on JDK 21

AI-assisted (Composer 2.5); human-reviewed.