### PR TITLE
Return `null` from `nextStringValue()` at end of input

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -183,3 +183,6 @@ Christian Beikov (@beikov)
  * Fixed #893: Decode element name before matching virtual wrapper in
    `_initStartElement`
   (3.3.0)
+ * Fixed #899: Return `null` from `nextStringValue()` at end-of-input (instead
+   of throwing `IllegalStateException`)
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -28,6 +28,9 @@ Version: 3.x (for earlier see VERSION-2.x)
  (fix by @Sahana2524)
 #893: Decode element name before matching virtual wrapper in `_initStartElement`
  (fix by @Sahana2524)
+#899: Return `null` from `nextStringValue()` at end-of-input (instead of
+  throwing `IllegalStateException`)
+ (fix by @Sahana2524)
 
 3.2.2 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/tools/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -996,6 +996,7 @@ _currText);
             break;
         case XmlTokenStream.XML_END:
             _updateTokenToNull();
+            break;
         default:
             return _internalErrorUnknownToken(token);
         }

--- a/src/test/java/tools/jackson/dataformat/xml/stream/XmlParserNextXxxTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/stream/XmlParserNextXxxTest.java
@@ -7,6 +7,7 @@ import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.deser.FromXmlParser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class XmlParserNextXxxTest extends XmlTestUtil
 {
@@ -41,6 +42,28 @@ public class XmlParserNextXxxTest extends XmlTestUtil
         assertEquals("9", xp.getString());
 
         assertToken(JsonToken.END_OBJECT, xp.nextToken()); // </data>
+        xp.close();
+    }
+
+    // nextStringValue() must honor the JsonParser contract at end of input:
+    // return null, same as nextToken() does, instead of leaking an unchecked
+    // IllegalStateException from the internal XML_END branch.
+    @Test
+    public void testNextStringValueAtEndOfInput() throws Exception
+    {
+        final String XML = "<data max=\"7\" offset=\"9\"/>";
+
+        JsonParser xp = xmlMapper(false).createParser(XML);
+
+        assertToken(JsonToken.START_OBJECT, xp.nextToken()); // <data>
+        assertToken(JsonToken.PROPERTY_NAME, xp.nextToken()); // max
+        assertEquals("7", xp.nextStringValue());
+        assertToken(JsonToken.PROPERTY_NAME, xp.nextToken()); // offset
+        assertEquals("9", xp.nextStringValue());
+        assertToken(JsonToken.END_OBJECT, xp.nextToken()); // </data>
+
+        // One more call past the end: should quietly report end-of-input
+        assertNull(xp.nextStringValue());
         xp.close();
     }
 }

--- a/src/test/java/tools/jackson/dataformat/xml/stream/XmlParserNextXxxTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/stream/XmlParserNextXxxTest.java
@@ -45,9 +45,9 @@ public class XmlParserNextXxxTest extends XmlTestUtil
         xp.close();
     }
 
-    // nextStringValue() must honor the JsonParser contract at end of input:
-    // return null, same as nextToken() does, instead of leaking an unchecked
-    // IllegalStateException from the internal XML_END branch.
+    // [dataformat-xml#899]: nextStringValue() must honor the JsonParser contract
+    // at end of input: return null, same as nextToken() does, instead of leaking
+    // an unchecked IllegalStateException from the internal XML_END branch.
     @Test
     public void testNextStringValueAtEndOfInput() throws Exception
     {


### PR DESCRIPTION
    java.lang.IllegalStateException: Internal error: unrecognized XmlTokenStream token: 8

nextStringValue() runs the XmlTokenStream event through a switch, but the XML_END branch has no break and falls into the default: case that throws. So one call past the last token raises an unchecked exception instead of reporting end-of-input as null, the way nextToken() already does for XML_END. Callers that only catch JacksonException do not see it.

Added the missing break so the XML_END case reaches the method's shared `return null`. Extended the existing `XmlParserNextXxxTest` with one call past the end, which throws on the current tree and now returns null.