### PR TITLE
Return null from nextTextValue() at end of input (2.x port of #899)

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -287,3 +287,6 @@ Sahana (@Sahana2524)
 * Contributed #891: Enforce `StreamReadConstraints.maxNestingDepth` in
   `FromXmlParser`
  (2.18.10)
+* Fixed #899: Return `null` from `nextTextValue()` at end-of-input (instead of
+  throwing `IllegalStateException`)
+ (2.23.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,7 +6,9 @@ Project: jackson-dataformat-xml
 
 2.23.0 (not yet released)
 
-No changes since 2.22
+#899: Return `null` from `nextTextValue()` at end-of-input (instead of
+  throwing `IllegalStateException`)
+ (fix by @Sahana2524)
 
 2.22.2 (16-Aug-2026)
 2.22.1 (07-Jul-2026)

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/FromXmlParser.java
@@ -1052,6 +1052,7 @@ XmlTokenStream.XML_END_ELEMENT, XmlTokenStream.XML_START_ELEMENT, token));
             break;
         case XmlTokenStream.XML_END:
             _updateTokenToNull();
+            break;
         default:
             return _internalErrorUnknownToken(token);
         }

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlParserNextXxxTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/stream/XmlParserNextXxxTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlTestUtil;
 import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class XmlParserNextXxxTest extends XmlTestUtil
 {
@@ -55,6 +56,28 @@ public class XmlParserNextXxxTest extends XmlTestUtil
         assertEquals("9", xp.getText());
 
         assertToken(JsonToken.END_OBJECT, xp.nextToken()); // </data>
+        xp.close();
+    }
+
+    // [dataformat-xml#899]: nextTextValue() must honor the JsonParser contract
+    // at end of input: return null, same as nextToken() does, instead of leaking
+    // an unchecked IllegalStateException from the internal XML_END branch.
+    @Test
+    public void testNextTextValueAtEndOfInput() throws Exception
+    {
+        final String XML = "<data max=\"7\" offset=\"9\"/>";
+
+        FromXmlParser xp = (FromXmlParser) _xmlFactory.createParser(new StringReader(XML));
+
+        assertToken(JsonToken.START_OBJECT, xp.nextToken()); // <data>
+        assertToken(JsonToken.FIELD_NAME, xp.nextToken()); // max
+        assertEquals("7", xp.nextTextValue());
+        assertToken(JsonToken.FIELD_NAME, xp.nextToken()); // offset
+        assertEquals("9", xp.nextTextValue());
+        assertToken(JsonToken.END_OBJECT, xp.nextToken()); // </data>
+
+        // One more call past the end: should quietly report end-of-input
+        assertNull(xp.nextTextValue());
         xp.close();
     }
 }


### PR DESCRIPTION
Port of #899 (3.x, by @Sahana2524) to the 2.x line.

`FromXmlParser.nextTextValue()` runs the `XmlTokenStream` event through a switch in which the `XML_END` branch has no `break`, so it falls into `default:` and throws:

    java.lang.IllegalStateException: Internal error: unrecognized XmlTokenStream token: 8

One call past the last token therefore raises an unchecked exception instead of reporting end-of-input as `null`, the way `nextToken()` already does for `XML_END`. Callers that only catch `JsonProcessingException` do not see it.

Adds the missing `break` so `XML_END` reaches the method's shared `return null`, plus a test in `XmlParserNextXxxTest` making one call past the end (throws on 2.x as-is, returns `null` with the fix).

Verified: full 2.x suite green (423 tests); the new test fails without the one-line change and passes with it. Release notes updated for 2.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)