### PR TITLE
Split embedded `]]>` across CDATA sections when serializing

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -189,3 +189,5 @@ Christian Beikov (@beikov)
  * Fixed #899: Return `null` from `nextStringValue()` at end-of-input (instead
    of throwing `IllegalStateException`)
   (3.3.0)
+ * Fixed #903: Split embedded `]]>` across CDATA sections when serializing
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -33,6 +33,8 @@ Version: 3.x (for earlier see VERSION-2.x)
 #899: Return `null` from `nextStringValue()` at end-of-input (instead of
   throwing `IllegalStateException`)
  (fix by @Sahana2524)
+#903: Split embedded `]]>` across CDATA sections when serializing
+ (fix by @Sahana2524)
 
 3.2.2 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -856,7 +856,7 @@ public class ToXmlGenerator
                 //   but for now, let's just make sure structure is correct
                 //if (_xmlPrettyPrinter != null) { ... }
                 if(_nextIsCData) {
-                    _xmlWriter.writeCData(text);
+                    StaxUtil.writeCData(_xmlWriter, text);
                 } else {
                     _xmlWriter.writeCharacters(text);
                 }
@@ -867,7 +867,7 @@ public class ToXmlGenerator
             } else {
                 _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
                 if(_nextIsCData) {
-                    _xmlWriter.writeCData(text);
+                    StaxUtil.writeCData(_xmlWriter, text);
                 } else {
                     _xmlWriter.writeCharacters(text);
                 }
@@ -892,7 +892,7 @@ public class ToXmlGenerator
             } else if (checkNextIsUnwrapped()) {
             	// should we consider pretty-printing or not?
                 if(_nextIsCData) {
-                    _xmlWriter.writeCData(text, offset, len);
+                    StaxUtil.writeCData(_xmlWriter, text, offset, len);
                 } else {
                     _xmlWriter.writeCharacters(text, offset, len);
                 }
@@ -903,7 +903,7 @@ public class ToXmlGenerator
             } else {
                 _xmlWriter.writeStartElement(_nextName.getNamespaceURI(), _nextName.getLocalPart());
                 if(_nextIsCData) {
-                    _xmlWriter.writeCData(text, offset, len);
+                    StaxUtil.writeCData(_xmlWriter, text, offset, len);
                 } else {
                     _xmlWriter.writeCharacters(text, offset, len);
                 }

--- a/src/main/java/tools/jackson/dataformat/xml/util/DefaultXmlPrettyPrinter.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/DefaultXmlPrettyPrinter.java
@@ -290,7 +290,7 @@ public class DefaultXmlPrettyPrinter
         }
         sw.writeStartElement(nsURI, localName);
         if(isCData) {
-            sw.writeCData(text);
+            StaxUtil.writeCData(sw, text);
         } else {
             sw.writeCharacters(text);
         }
@@ -309,7 +309,7 @@ public class DefaultXmlPrettyPrinter
         }
         sw.writeStartElement(nsURI, localName);
         if(isCData) {
-            sw.writeCData(buffer, offset, len);
+            StaxUtil.writeCData(sw, buffer, offset, len);
         } else {
             sw.writeCharacters(buffer, offset, len);
         }

--- a/src/main/java/tools/jackson/dataformat/xml/util/StaxUtil.java
+++ b/src/main/java/tools/jackson/dataformat/xml/util/StaxUtil.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import javax.xml.stream.*;
 
+import org.codehaus.stax2.XMLStreamWriter2;
+
 import tools.jackson.core.*;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.exc.StreamWriteException;
@@ -34,6 +36,46 @@ public class StaxUtil
         if (t instanceof Error e) throw e;
         if (t instanceof RuntimeException re) throw re;
         return t;
+    }
+
+    /**
+     * Writes {@code text} as one or more CDATA sections. XML does not allow the
+     * sequence {@code "]]>"} inside a CDATA block, so where it occurs the value is
+     * split: the {@code "]]"} ends one section and the {@code ">"} starts the next.
+     * A coalescing reader (the default for this module) reads the pieces back as
+     * the original text, so a value containing {@code "]]>"} round-trips instead of
+     * making the underlying Stax writer reject it.
+     */
+    public static void writeCData(XMLStreamWriter2 sw, String text)
+        throws XMLStreamException
+    {
+        int ix = text.indexOf("]]>");
+        if (ix < 0) {
+            sw.writeCData(text);
+            return;
+        }
+        int start = 0;
+        do {
+            // keep the "]]" in this section, push the ">" into the next one
+            sw.writeCData(text.substring(start, ix + 2));
+            start = ix + 2;
+            ix = text.indexOf("]]>", start);
+        } while (ix >= 0);
+        sw.writeCData(text.substring(start));
+    }
+
+    public static void writeCData(XMLStreamWriter2 sw, char[] buffer, int offset, int len)
+        throws XMLStreamException
+    {
+        // Common case has no "]]>" in range, so avoid allocating a String for it
+        final int end = offset + len;
+        for (int i = offset; i < end - 2; ++i) {
+            if (buffer[i] == ']' && buffer[i + 1] == ']' && buffer[i + 2] == '>') {
+                writeCData(sw, new String(buffer, offset, len));
+                return;
+            }
+        }
+        sw.writeCData(buffer, offset, len);
     }
 
     private static String _message(Throwable t1, Throwable t2) {

--- a/src/test/java/tools/jackson/dataformat/xml/ser/CDataEndMarkerSerTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/ser/CDataEndMarkerSerTest.java
@@ -1,0 +1,49 @@
+package tools.jackson.dataformat.xml.ser;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlCData;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// Values written as CDATA must survive serialization even when they contain
+// the "]]>" sequence that closes a CDATA section.
+public class CDataEndMarkerSerTest extends XmlTestUtil
+{
+    static class CDataBean
+    {
+        @JacksonXmlCData
+        public String value;
+
+        public CDataBean() { }
+        public CDataBean(String v) { value = v; }
+    }
+
+    private final XmlMapper MAPPER = newMapper();
+
+    @Test
+    public void testCDataWithEndMarkerRoundTrip() throws Exception
+    {
+        _roundTrip("a]]>b");
+        _roundTrip("]]>");
+        _roundTrip("]]>]]>");
+        _roundTrip("trailing]]>");
+        _roundTrip("<![CDATA[nested]]>tail");
+    }
+
+    @Test
+    public void testCDataWithoutEndMarkerUnchanged() throws Exception
+    {
+        String xml = MAPPER.writeValueAsString(new CDataBean("plain"));
+        assertEquals("<CDataBean><value><![CDATA[plain]]></value></CDataBean>", xml);
+    }
+
+    private void _roundTrip(String value) throws Exception
+    {
+        String xml = MAPPER.writeValueAsString(new CDataBean(value));
+        CDataBean result = MAPPER.readValue(xml, CDataBean.class);
+        assertEquals(value, result.value, "round-trip failed for XML: " + xml);
+    }
+}


### PR DESCRIPTION
**CDATA values containing `]]>` fail to serialize**

A `@JacksonXmlCData` string is handed straight to `writeCData`, and since `]]>` closes a CDATA section the underlying Woodstox writer rejects it, so any value carrying that sequence cannot be written at all and the round-trip guarantee breaks. The safe form is to split at each `]]>` (keep the `]]` in one section, push the `>` into the next); a coalescing reader, which is the default here, reads the pieces back as the original text. I put the split in a shared `StaxUtil.writeCData` helper so the plain and pretty-printing paths behave the same.