### PR TITLE
Clear forced `xsi:type` attribute state in `ToXmlGenerator.writeName`

### DIFF
--- a/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
+++ b/src/main/java/tools/jackson/dataformat/xml/ser/ToXmlGenerator.java
@@ -192,6 +192,17 @@ public class ToXmlGenerator
     protected boolean _nextIsCData = false;
 
     /**
+     * Marker set by {@link #writeName(String)} when it forces attribute mode
+     * and the XSI namespace onto the next value to emit a synthetic
+     * {@code xsi:type} attribute. Bean serializers clear it by assigning the
+     * following name via {@link #setNextName}; for content-driven names
+     * (Map / JsonNode / {@code @JsonAnyGetter}) nothing else does, so the next
+     * {@link #writeName} clears it to keep the forced state from leaking onto a
+     * following sibling.
+     */
+    protected boolean _nextIsXsiType = false;
+
+    /**
      * To support proper serialization of arrays it is necessary to keep
      * stack of element names, so that we can "revert" to earlier 
      */
@@ -501,6 +512,8 @@ public class ToXmlGenerator
     public final void setNextName(QName name)
     {
         _nextName = name;
+        // Caller is taking over naming, so drop any pending xsi:type forcing
+        _nextIsXsiType = false;
     }
 
     /**
@@ -609,12 +622,26 @@ public class ToXmlGenerator
             _reportError("Can not write a property name, expecting a value");
         }
 
+        // A preceding synthetic "xsi:type" name forces attribute mode and the XSI
+        // namespace onto _nextName so the type-id value can be written as an
+        // attribute. Bean serializers reset that by assigning the next name via
+        // setNextName(); content-driven names (Map/JsonNode/@JsonAnyGetter) do not,
+        // so clear it here. Otherwise the following sibling inherits attribute-ness
+        // and the XSI namespace, producing xsi:-prefixed attributes (or a duplicate
+        // xsi:type) that this module can no longer read back.
+        if (_nextIsXsiType) {
+            _nextIsXsiType = false;
+            _nextIsAttribute = false;
+            _nextName = null;
+        }
+
         // 30-Jan-2024, tatu: Surprise!
         if (XmlWriteFeature.AUTO_DETECT_XSI_TYPE.enabledIn(_formatFeatures)
                 && "xsi:type".equals(name)) {
             setNextName(new QName(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI,
                     "type", "xsi"));
             setNextIsAttribute(true);
+            _nextIsXsiType = true;
         } else if (name.equals(_cfgNameForTextElement)) {
             // [dataformat-xml#629]: Name matching the "unnamed text property" marker
             //   (FromXmlParser.DEFAULT_UNNAMED_TEXT_PROPERTY, default "") represents

--- a/src/test/java/tools/jackson/dataformat/xml/ser/XsiTypeWriteTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/ser/XsiTypeWriteTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
+import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.dataformat.xml.XmlTestUtil;
 import tools.jackson.dataformat.xml.XmlWriteFeature;
@@ -67,5 +68,43 @@ public class XsiTypeWriteTest extends XmlTestUtil
                 a2q("<Poly xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:type='PolyBean'>"
                         +"<value>42</value></Poly>"),
                 a2q(XSI_ENABLED_MAPPER.writeValueAsString(new PolyBean())));
+    }
+
+    // Content-driven names (Map/JsonNode) that happen to include an "xsi:type"
+    // key must not leave following siblings in attribute mode / the XSI namespace.
+    // Before the fix the forced state leaked, so siblings became xsi:-prefixed
+    // attributes -- and a colliding "type" key produced a duplicate xsi:type
+    // attribute, i.e. XML this module could no longer read back.
+    @Test
+    public void testXsiTypeKeyDoesNotLeakOntoSibling() throws Exception
+    {
+        XmlMapper mapper = newMapper();
+        ObjectNode tree = mapper.createObjectNode();
+        tree.put("xsi:type", "A");
+        tree.put("type", "B");
+        String xml = mapper.writeValueAsString(tree);
+        assertEquals(
+                a2q("<ObjectNode xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
+                        +" xsi:type='A'><type>B</type></ObjectNode>"),
+                a2q(xml));
+        // and the emitted document must round-trip through the same module
+        assertEquals(tree, mapper.readTree(xml));
+    }
+
+    @Test
+    public void testXsiTypeKeyFollowedByNilKey() throws Exception
+    {
+        XmlMapper mapper = newMapper();
+        ObjectNode tree = mapper.createObjectNode();
+        tree.put("xsi:type", "T");
+        tree.put("nil", "true");
+        String xml = mapper.writeValueAsString(tree);
+        assertEquals(
+                a2q("<ObjectNode xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
+                        +" xsi:type='T'><nil>true</nil></ObjectNode>"),
+                a2q(xml));
+        // previously the leaked attribute mode emitted xsi:nil='true', collapsing
+        // the whole document to null on read
+        assertEquals(tree, mapper.readTree(xml));
     }
 }


### PR DESCRIPTION
`writeName`'s synthetic `xsi:type` handling forces attribute mode and the XSI namespace onto the next value, and only the bean-serializer path clears it (by assigning the next name through `setNextName`):

- a `Map` / `JsonNode` / `@JsonAnyGetter` key of `xsi:type` leaves every following sibling as an `xsi:`-prefixed attribute instead of an element
- `{"xsi:type":"A","type":"B"}` emits a duplicate `xsi:type` attribute, so the module produces XML it can no longer read back
- `{"xsi:type":"T","nil":"true"}` emits `xsi:nil="true"`, so the whole document reads back as `null`

Clears the forced state on the next `writeName` for the content-driven case; the bean path already reset it via `setNextName`, so legitimate polymorphic output is unchanged.
