### PR TITLE
verify Stax factory type before instantiating in XmlFactory.readResolve()

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -193,3 +193,6 @@ Christian Beikov (@beikov)
  * Fixed #899: Return `null` from `nextStringValue()` at end-of-input (instead
    of throwing `IllegalStateException`)
   (3.3.0)
+ * Fixed #910: Verify Stax factory type before instantiating in
+   `XmlFactory.readResolve()`
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -9,6 +9,8 @@ Version: 3.x (for earlier see VERSION-2.x)
 
 #873: Fix handling of `@JsonApplyView`
  (fix by @cowtowncoder, w/ Claude code)
+#910: Verify Stax factory type before instantiating in `XmlFactory.readResolve()`
+ (fix by @Sahana2524)
 #878: Re-apply entity/DTD hardening after JDK deserialization of `XmlFactory`
  (fix by @Sahana2524)
 #879: Use `Locale.ROOT` for case folding in `CaseInsensitiveNameSet`

--- a/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
+++ b/src/main/java/tools/jackson/dataformat/xml/XmlFactory.java
@@ -247,13 +247,28 @@ public class XmlFactory
             // would have set, otherwise a securely-built factory comes back with
             // external entity + DTD processing re-enabled (see [dataformat-xml#190], [dataformat-xml#211]).
             inf = XmlFactoryBuilder.secureXmlInputFactory(
-                    (XMLInputFactory) Class.forName(_jdkXmlInFactory).getDeclaredConstructor().newInstance());
-            outf = (XMLOutputFactory) Class.forName(_jdkXmlOutFactory).getDeclaredConstructor().newInstance();
+                    _staxFactoryForName(XMLInputFactory.class, _jdkXmlInFactory));
+            outf = _staxFactoryForName(XMLOutputFactory.class, _jdkXmlOutFactory);
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
         return new XmlFactory(_formatReadFeatures, _formatWriteFeatures,
                 inf, outf, _nameProcessor, _cfgNameForTextElement);
+    }
+
+    // The Stax factory class names come off a JDK-serialized stream, which may be
+    // attacker-controlled. The old code passed each straight to
+    // `Class.forName(name).getDeclaredConstructor().newInstance()`, which loads,
+    // static-initializes and instantiates ANY class named there before checking its
+    // type -- so a tampered stream could run the static initializer and no-arg
+    // constructor of an arbitrary class on the classpath. Load without initializing,
+    // confirm the class really is the expected Stax factory type, and only then
+    // initialize and construct it. Legitimate factory class names are unaffected.
+    private static <T> T _staxFactoryForName(Class<T> expType, String className)
+        throws ReflectiveOperationException
+    {
+        final Class<?> raw = Class.forName(className, false, XmlFactory.class.getClassLoader());
+        return raw.asSubclass(expType).getDeclaredConstructor().newInstance();
     }
 
     /**

--- a/src/test/java/tools/jackson/dataformat/xml/misc/FactoryDeserClassNameTest.java
+++ b/src/test/java/tools/jackson/dataformat/xml/misc/FactoryDeserClassNameTest.java
@@ -1,0 +1,88 @@
+package tools.jackson.dataformat.xml.misc;
+
+import java.io.*;
+import java.util.Arrays;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.dataformat.xml.XmlFactory;
+import tools.jackson.dataformat.xml.XmlTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+// [dataformat-xml#910]: the Stax factory class names read back during JDK
+// deserialization of `XmlFactory` must be verified to be actual Stax factory
+// types before the named class is initialized/instantiated. A tampered stream
+// naming an unrelated class must not get to run that class.
+public class FactoryDeserClassNameTest extends XmlTestUtil
+{
+    // A real `XMLInputFactory`, used only so the serialized class name has a
+    // known length we can substitute without disturbing the stream framing.
+    public static class StubInFactory extends WstxInputFactory { }
+
+    // Non-factory stand-in for an arbitrary classpath class. Its FQN must match
+    // StubInFactory's byte length so the substitution below keeps the
+    // ObjectOutputStream block-data framing intact (the two class names are
+    // written into one length-prefixed block).
+    public static class TripwireClass {
+        public static volatile boolean CONSTRUCTED = false;
+        public TripwireClass() {
+            CONSTRUCTED = true;
+        }
+    }
+
+    @Test
+    public void testUnexpectedFactoryClassNotInstantiated() throws Exception
+    {
+        final String realInName = StubInFactory.class.getName();
+        final String fakeName = TripwireClass.class.getName();
+        // Guard: equal length keeps the writeUTF block-data length header valid.
+        assertEquals(realInName.length(), fakeName.length(),
+                "test class names must be equal length");
+
+        final XmlFactory f = XmlFactory.builder()
+                .xmlInputFactory(new StubInFactory())
+                .build();
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream os = new ObjectOutputStream(bytes)) {
+            os.writeObject(f);
+        }
+        byte[] tampered = replaceUtf(bytes.toByteArray(), realInName, fakeName);
+
+        TripwireClass.CONSTRUCTED = false;
+        assertThrows(Exception.class, () -> {
+            try (ObjectInputStream is = new ObjectInputStream(
+                    new ByteArrayInputStream(tampered))) {
+                is.readObject();
+            }
+        });
+        // Before the fix the named class was loaded and instantiated before the
+        // (failing) cast to `XMLInputFactory`; after the fix the type check runs
+        // on the uninitialized class, so it is never constructed.
+        assertFalse(TripwireClass.CONSTRUCTED,
+                "Unexpected class must not be instantiated during deserialization");
+    }
+
+    private static byte[] replaceUtf(byte[] data, String from, String to) throws IOException {
+        final byte[] f = from.getBytes("UTF-8");
+        final byte[] t = to.getBytes("UTF-8");
+        for (int i = 0; i + 2 + f.length <= data.length; ++i) {
+            int len = ((data[i] & 0xff) << 8) | (data[i + 1] & 0xff);
+            if (len == f.length
+                    && Arrays.equals(Arrays.copyOfRange(data, i + 2, i + 2 + f.length), f)) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                out.write(data, 0, i);
+                out.write((t.length >> 8) & 0xff);
+                out.write(t.length & 0xff);
+                out.write(t);
+                out.write(data, i + 2 + f.length, data.length - (i + 2 + f.length));
+                return out.toByteArray();
+            }
+        }
+        throw new IllegalStateException("Could not locate class name in serialized stream");
+    }
+}


### PR DESCRIPTION
**Unverified class instantiation in `XmlFactory.readResolve()`**

The Stax factory class names come back off the JDK-serialized stream (`readObject` reads them via `readUTF`), but both were handed straight to `Class.forName(name).getDeclaredConstructor().newInstance()`, so a tampered `XmlFactory`/`XmlMapper` runs the static initializer and no-arg constructor of any class named there before the cast to `XMLInputFactory`/`XMLOutputFactory` gets a chance to reject it. This is the same JDK-deserialization boundary #878 hardened for entity/DTD settings, just a different failure on it. Now each name is loaded without initializing (`Class.forName(name, false, loader)`), checked with `asSubclass(...)`, and only then constructed, so an unexpected type is refused before it can run; real factory class names round-trip exactly as before.

`2.x` has the same two call sites in its `readResolve()`, so happy to rebase this onto whichever branch you'd prefer it to land in.

AI tooling was used to help prepare this change.